### PR TITLE
Fix: broken links on the Artnet Plugin page

### DIFF
--- a/pages/09.plugins/01.art-net/default.v4.md
+++ b/pages/09.plugins/01.art-net/default.v4.md
@@ -60,11 +60,11 @@ Compatibility
 
 QLC+ has been tested with the following Art-Net softwares/devices:
 
-* [DMXking eDMX1 TX](https://dmxking.com/artnetsacn/edmx1) \- 1 Output device
-* [DMXking eDMX2 TX](https://dmxking.com/artnetsacn/edmx2-tx-rdm) \- 2 Outputs device
+* [DMXking eDMX1 TX](https://dmxking.com/artnetsacn/edmx1-max) \- 1 Output device
+* [DMXking eDMX2 TX](https://dmxking.com/artnetsacn/edmx2-max) \- 2 Outputs device
 * [Enttec Open DMX Ethernet (ODE)](https://www.enttec.com/index.php?main_menu=Products&pn=70305) \- Input/Output device
 * [OLA - Open Lighting Architecture](https://www.opendmx.net/index.php/Open_Lighting_Architecture) \- Input/Output software node
 * [Art-Net Controller LITE](https://sites.google.com/site/artnetcontroller/) \- Input controller for Android
-* [Art-Net Controller LITE](https://play.google.com/store/apps/details?id=com.litux.art_net_controller_lite) \- Input controller for Android
+* [Art-Net Controller LITE](https://play.google.com/store/apps/details?id=com.chfsoft.artnet_dmx_Lite) \- Input controller for Android
 * [Modul8](http://www.garagecube.com/modul8/)
 * [Jinx!](http://www.live-leds.de/) \- LED Matrix Control


### PR DESCRIPTION
Fix: DMXKing links 
Fix: Google Play link to artnet controller lite