### PR TITLE
Add: Message about where to save fixture definitions

### DIFF
--- a/pages/10.fixture-definition-editor/chapter.v4.md
+++ b/pages/10.fixture-definition-editor/chapter.v4.md
@@ -21,8 +21,7 @@ To use your fixture definitions in QLC+, you must save them in a location where 
     * Windows: it is a folder in your user (e.g. MyUser) directory: C:\\Users\\MyUser\\QLC+\\Fixtures
     * Mac OS: it is located in your user Library directory: $HOME/Library/Application\\ Support/QLC+/Fixtures
 
-**Important note: for many reasons, you SHOULD NOT save or copy your custom fixtures in the QLC+ system fixtures folder. The most important is that when you uninstall QLC+, the system fixtures folder gets deleted, so your fixtures.  
-You are recommended to save them in the user fixtures folder. To find it, please refer to the [Q & A section](/basics/questions-and-answers) of this documentation.**
+**Important note: you SHOULD NOT save or copy your custom fixtures into the QLC+ system fixtures folder. This is because when QLC+ is uninstalled, all the fixtures in this folder are deleted. It can also cause unintended conflicts between the system and your own fixture definitions.**
 
 Main toolbar
 ------------

--- a/pages/10.fixture-definition-editor/chapter.v4.md
+++ b/pages/10.fixture-definition-editor/chapter.v4.md
@@ -10,15 +10,23 @@ media_order: 'fixtureeditor_physical.png,fixtureeditor_aliases.png,fixtureeditor
 
 # Fixture Definition Editor
 
-Fixture Definition Editor is a separate application bundled together with QLC+ for creating and modifying [fixture definitions](/basics/glossary-and-concepts#fixtures) used by QLC+. The definitions tell QLC+ (and users) important details about fixtures, such as which channel is used for pan movement, what value in which channel changes the beam color to green, how the fixture is reset etc...
+The Fixture Definition Editor is a separate application bundled together with QLC+ for creating and modifying [fixture definitions](/basics/glossary-and-concepts#fixtures). Having a fixture definition for each of your lights allows QLC+ to know how to control them.
 
-The main window in the Fixture Editor is just an empty workspace that contains the actual editor windows used to edit fixture definitions.
+## Saving your fixture definitions
+
+To use your fixture definitions in QLC+, you must save them in a location where QLC+ expects to find them. There are two places where you can save your fixture definitions:
+1. In the same folder as your QLC+ workspace (Handy if you want to give your workspace to someone else)
+2. In the user fixtures folder found in the following locations:
+    * Linux: it is a hidden folder in your user home directory: $HOME/.qlcplus/Fixtures
+    * Windows: it is a folder in your user (e.g. MyUser) directory: C:\\Users\\MyUser\\QLC+\\Fixtures
+    * Mac OS: it is located in your user Library directory: $HOME/Library/Application\\ Support/QLC+/Fixtures
 
 **Important note: for many reasons, you SHOULD NOT save or copy your custom fixtures in the QLC+ system fixtures folder. The most important is that when you uninstall QLC+, the system fixtures folder gets deleted, so your fixtures.  
 You are recommended to save them in the user fixtures folder. To find it, please refer to the [Q & A section](/basics/questions-and-answers) of this documentation.**
 
 Main toolbar
 ------------
+The main window in the Fixture Editor is just an empty workspace that contains the actual editor windows used to edit fixture definitions. The following options are available to you:
 
 |     |     |
 | --- | --- |


### PR DESCRIPTION
The new versions of QLC+ support fixture definitions being saved in the same folder as the project. This commit updates the documentation to reflect this.