### PR TITLE
Fix/windows backslashes

### DIFF
--- a/pages/10.fixture-definition-editor/chapter.v4.md
+++ b/pages/10.fixture-definition-editor/chapter.v4.md
@@ -18,7 +18,7 @@ To use your fixture definitions in QLC+, you must save them in a location where 
 1. In the same folder as your QLC+ workspace (Handy if you want to give your workspace to someone else)
 2. In the user fixtures folder found in the following locations:
     * Linux: it is a hidden folder in your user home directory: `$HOME/.qlcplus/Fixtures`
-    * Windows: it is a folder in your user directory: `C:\\\\Users\\{Username}\\QLC+\Fixtures`
+    * Windows: it is a folder in your user directory: `C:\\Users\{Username}\QLC+\Fixtures`
     * Mac OS: it is located in your user Library directory: `$HOME/Library/Application\\ Support/QLC+/Fixtures`
 
 **Important note: you SHOULD NOT save or copy your custom fixtures into the QLC+ system fixtures folder. This is because when QLC+ is uninstalled, all the fixtures in this folder are deleted. It can also cause unintended conflicts between the system and your own fixture definitions.**

--- a/pages/11.advanced/05.custom-ui-style/default.v4.md
+++ b/pages/11.advanced/05.custom-ui-style/default.v4.md
@@ -13,7 +13,7 @@ The file name is  hard-coded into QLC+ and must be: `qlcplusStyle.qss`
 The style file must also be placed in a specific path which is:  
 
 * **Linux**: `$HOME/.qlcplus`
-* **Windows**: `C:\\\\Users\\{Username}\\QLC+\Fixtures`
+* **Windows**: `C:\\Users\{Username}\QLC+\Fixtures`
 * **OSX**: `$HOME/Library/Application\\ Support/QLC+`
 
 The theme file is divided in sections. Each section represents the UI items that will be modified when running QLC+. Unchanged sections can be omitted.  


### PR DESCRIPTION
The Grav markdown viewer works differently to GitHub. This PR fixes the markdown files but note that it may look different in other editors (and PDF)