### PR TITLE
Add custom client section to the OS2L plugin

### DIFF
--- a/pages/09.plugins/08.os2l/default.v4.md
+++ b/pages/09.plugins/08.os2l/default.v4.md
@@ -21,3 +21,15 @@ Once done, restart VDJ.
   
 Now go to QLC+, enable the OS2L plugin on any universe. If you have set a specific port in VDJ, open the OS2L configuration dialog and set the same port there.  
 Once done, QLC+ will start receiving signals from VDJ (joystick icon will blink beside the Universe box)
+
+Custom Clients
+--------------
+
+In order to support custom clients an Input Profile must be configured that maps OS2L message to channels. The OS2L plugin listens to the following events: `beat`, `cmd` and `btn`.
+
+A `beat` message will change the value at channel 8342 to 255 if received. Example: `{"evt":"beat"}`.
+
+A `cmd` message will set the the channel given by `id` to the value given by `param`. Example: `{"evt": "cmd", "id": "1", "param": 255}`.
+
+A `btn` message can also be mapped. The channel is controlled by a CRC of the `name`. The easiest way to figure the channel is to use the automatic input mapper when setting up the Input Profile. The value sent to the channel is either 255 on `on` or 0 on `off`. Example: `{"evt":"btn","name":"Light Left 2","state":"on"}`.
+

--- a/pages/09.plugins/08.os2l/default.v4_de.md
+++ b/pages/09.plugins/08.os2l/default.v4_de.md
@@ -21,3 +21,15 @@ Wenn Sie fertig sind, starten Sie VDJ neu.
   
 Gehen Sie nun zu QLC+ und aktivieren Sie das OS2L-Plugin in einem beliebigen Universum. Wenn Sie in VDJ einen bestimmten Port festgelegt haben, öffnen Sie den OS2L-Konfigurationsdialog und stellen Sie dort denselben Port ein.  
 Sobald dies erledigt ist, beginnt QLC+, Signale von VDJ zu empfangen (das Joystick-Symbol blinkt neben dem Universe-Feld).
+
+Client-Konfiguration
+--------------
+
+Um andere Clients zu unterstützen, muss ein Eingabeprofil erstellt werden, welches OS2L Nachrichten den Kanälen zuweist. Das OS2L Plugin hört auf folgende Events: `beat`, `cmd` und `btn`.
+
+Eine `beat` Nachricht ändert den Wert des Kanals 8342 auf 255. Beispiel: `{"evt":"beat"}`.
+
+Eine `cmd` Nachricht addressiert den Kanal mit der Nummer gegebn durch `id` und setzt den Wert gegeben durch `param`. Beispiel: `{"evt": "cmd", "id": "1", "param": 255}`.
+
+Eine `btn` Nachricht kann auch Konfiguriert werden. Die Kanalnummer wird vom CRC des `name` Parameters abgeleitet. Der einfachste Weg um die Kanalnummer herauszufinden, ist durch den Automatikmodus im Eingabeprofil. Der Wert, der auf den Kanal gelegt wird, ist entweder 255 bei einem `state` von `on` bzw. 0 bei `off`. Beispiel: `{"evt":"btn","name":"Light Left 2","state":"on"}`.
+


### PR DESCRIPTION
To help client developers better understand how the OS2L plugin works in QLC+