### PR TITLE
Create sepearate GitHub action for pdf build

### DIFF
--- a/.github/actions/build-pdf/action.yml
+++ b/.github/actions/build-pdf/action.yml
@@ -1,0 +1,113 @@
+name: Build PDF
+
+inputs:
+  lang:
+    description: Documentation language
+    required: false
+    default: "en"
+
+outputs:
+  pdf_path:
+    description: Path to resulting PDF
+    value: ${{ steps.set-output.outputs.pdf }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install PowerShell
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y powershell
+    - name: Install ImageMagick
+      shell: bash
+      run: sudo apt-get install -y imagemagick
+    - name: Install ghostscript
+      shell: bash
+      run: sudo apt-get install -y ghostscript
+    - name: Install GitHub CLI
+      shell: bash
+      run: sudo apt-get install -y gh
+    - name: Create output directories
+      shell: bash
+      run: |
+        mkdir -p ./.github/workflows/bin/temp
+        mkdir -p ./.github/workflows/bin/markdown
+        mkdir -p ./.github/workflows/bin/pdf
+    - name: Run PowerShell merge script
+      shell: pwsh
+      run: |
+        ./scripts/Merge-MarkdownFiles.ps1 -Lang ${{ inputs.lang }}
+    - name: Fix logo and copy images
+      shell: bash
+      run: |
+        cp -r ./.github/workflows/bin/markdown/images ./images
+        sed -i '/!\[\](images\/qlcplus\.svg)/d' ./.github/workflows/bin/markdown/qlcplus-docs.md
+    - name: Normalize image DPI
+      shell: bash
+      run: |
+        for file in ./images/*.{jpg,jpeg,png,tiff,bmp}; do
+          if [[ -f "$file" ]]; then
+            convert "$file" -units PixelsPerInch -density 96 "$file"
+          fi
+        done
+    - name: Fetch Latest Release
+      id: get_release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        RELEASE=$(gh release view --json tagName --jq .tagName || echo "")
+        echo "LATEST_RELEASE=$RELEASE" >> $GITHUB_ENV
+    - name: Put current date into a variable
+      shell: bash
+      run: echo "EXPORT_DATE=$(date --rfc-3339=date)" >> ${GITHUB_ENV}
+    - name: Build PDF
+      uses: docker://pandoc/extra
+      with:
+        args: >-
+          -s -o ./.github/workflows/bin/temp/QLCplusDocumentation.pdf
+          ./.github/workflows/bin/markdown/qlcplus-docs.md
+          --listings
+          --pdf-engine=lualatex
+          -V papersize=a4
+          -V geometry:margin=1.5cm
+          -V classoption=oneside
+          -V indent=false
+          -V toc=true
+          -V toc-title="Table of Contents"
+          -V mainfont="Source Sans Pro"
+          -V sansfont="Source Sans Pro"
+          -f markdown-raw_tex
+    - name: Create Title Page Markdown
+      shell: bash
+      run: |
+        echo '![​](images/qlcplus.svg){ style="width: 50%; margin: auto;" }' >> ./.github/workflows/bin/temp/titlepage.md
+    - name: Convert Title Page to PDF
+      uses: docker://pandoc/extra
+      with:
+        args: >-
+          -s -o ./.github/workflows/bin/temp/titlepage.pdf
+          ./.github/workflows/bin/temp/titlepage.md
+          --pdf-engine=lualatex
+          --template=./scripts/template.tex
+          --verbose
+          -V mainfont="Source Sans Pro"
+          -V sansfont="Source Sans Pro"
+          -V title="Q Light Controller + Documentation"
+          -V subtitle="Comprehensive Guide"
+          -V author="docs.qlcplus.org"
+          -V date="${{ env.EXPORT_DATE }}"
+          -V release="${{ env.LATEST_RELEASE }}"
+    - name: Combine Title Page and Documentation PDFs
+      shell: bash
+      run: |
+        gs -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=./.github/workflows/bin/pdf/qlcplus-docs-${{ inputs.lang }}.pdf ./.github/workflows/bin/temp/titlepage.pdf ./.github/workflows/bin/temp/QLCplusDocumentation.pdf
+    - name: Cleanup temporary items
+      shell: bash
+      run: |
+        rm -rf ./.github/workflows/bin/temp/
+        rm -rf ./.github/workflows/bin/markdown/images/
+    - id: set-output
+      shell: bash
+      run: echo "pdf=./.github/workflows/bin/pdf/qlcplus-docs-${{ inputs.lang }}.pdf" >> $GITHUB_OUTPUT

--- a/.github/actions/build-pdf/action.yml
+++ b/.github/actions/build-pdf/action.yml
@@ -51,11 +51,11 @@ runs:
             convert "$file" -units PixelsPerInch -density 96 "$file"
           fi
         done
-    - name: Fetch Latest Release
+    - name: Get latest release tag
       id: get_release
       shell: bash
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
       run: |
         RELEASE=$(gh release view --json tagName --jq .tagName || echo "")
         echo "LATEST_RELEASE=$RELEASE" >> $GITHUB_ENV

--- a/.github/actions/build-pdf/action.yml
+++ b/.github/actions/build-pdf/action.yml
@@ -55,7 +55,7 @@ runs:
       id: get_release
       shell: bash
       env:
-        GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN:  ${{ github.token }}
       run: |
         RELEASE=$(gh release view --json tagName --jq .tagName || echo "")
         echo "LATEST_RELEASE=$RELEASE" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,107 +17,13 @@ jobs:
   build-pdf:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      
-    - name: Install PowerShell
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y powershell
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Create output paths
-      run: |
-        mkdir -p ./.github/workflows/bin/temp
-        mkdir -p ./.github/workflows/bin/markdown
-        mkdir -p ./.github/workflows/bin/pdf
-
-    - name: Run PowerShell script
-      shell: pwsh
-      run: |
-        ./scripts/Merge-MarkdownFiles.ps1
-
-    - name: Fix logo and copy images to root directory for pandoc # images directory is deleted in "Cleanup temporary items" step
-      run: |
-        cp -r ./.github/workflows/bin/markdown/images ./images
-        sed -i '/!\[\](images\/qlcplus\.svg)/d'  ./.github/workflows/bin/markdown/qlcplus-docs.md 
-
-    - name: Install ImageMagick for image normalization
-      run: sudo apt-get install -y imagemagick
-
-    - name: Normalize image DPI
-      run: |
-        for file in ./images/*.{jpg,jpeg,png,tiff,bmp}; do
-          if [[ -f "$file" ]]; then
-            convert "$file" -units PixelsPerInch -density 96 "$file"
-            echo "Processed $file"
-          fi
-        done
-
-    - name: Install GitHub CLI
-      run: sudo apt-get install gh
-
-    - name: Fetch Latest Release
-      id: get_release
-      env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Set the token for GitHub CLI authentication
-      run: |
-          RELEASE=$(gh release view --json tagName --jq .tagName)
-          echo "LATEST_RELEASE=$RELEASE" >> $GITHUB_ENV
-
-    - name: Put current date into a variable
-      run: |
-        echo "EXPORT_DATE=$(date --rfc-3339=date)" >> ${GITHUB_ENV}
-    
-    - name: Build PDF
-      uses: docker://pandoc/extra
-      with:
-          args: >
-            -s -o ./.github/workflows/bin/temp/QLCplusDocumentation.pdf
-            ./.github/workflows/bin/markdown/qlcplus-docs.md 
-            --listings 
-            --pdf-engine=lualatex
-            -V papersize=a4 
-            -V geometry:margin=1.5cm
-            -V classoption=oneside 
-            -V indent=false
-            -V toc=true
-            -V toc-title="Table of Contents"
-            -V mainfont="Source Sans Pro"
-            -V sansfont="Source Sans Pro"
-            -f markdown-raw_tex 
-
-    - name: Create Title Page Markdown
-      run: |
-              echo '![​](images/qlcplus.svg){ style="width: 50%; margin: auto;" }'  >>  ./.github/workflows/bin/temp/titlepage.md
-              
-    - name: Convert Title Page to PDF
-      uses: docker://pandoc/extra
-      with:
-          args: >
-                -s -o ./.github/workflows/bin/temp/titlepage.pdf 
-                ./.github/workflows/bin/temp/titlepage.md 
-                --pdf-engine=lualatex
-                --template=./scripts/template.tex
-                --verbose
-                -V mainfont="Source Sans Pro"
-                -V sansfont="Source Sans Pro"
-                -V title="Q Light Controller + Documentation"
-                -V subtitle="Comprehensive Guide"
-                -V author="docs.qlcplus.org"
-                -V date="${{env.EXPORT_DATE}}"
-                -V release="${{env.LATEST_RELEASE}}"
-                  
-
-    - name: Combine Title Page and Documentation PDFs
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y ghostscript
-        gs -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=./.github/workflows/bin/pdf/qlcplus-docs.pdf ./.github/workflows/bin/temp/titlepage.pdf ./.github/workflows/bin/temp/QLCplusDocumentation.pdf
-     
-    - name: Cleanup temporary items
-      run: |
-        rm -rf ./.github/workflows/bin/temp/
-        rm -rf ./.github/workflows/bin/images/
+      - id: build
+        uses: ./.github/actions/build-pdf
+        with:
+          lang: en
 
     - name: Upload-PDF
       uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - id: build
-        uses: ./.github/actions/build-pdf.yml
+        uses: ./.github/actions/build-pdf
         with:
           lang: en
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,18 +21,18 @@ jobs:
         uses: actions/checkout@v4
 
       - id: build
-        uses: ./.github/actions/build-pdf
+        uses: ./.github/actions/build-pdf.yml
         with:
           lang: en
 
-    - name: Upload-PDF
-      uses: actions/upload-artifact@v4
-      with:
-          name: qlcplus-docs-en-pdf
-          path: ./.github/workflows/bin/pdf/
-
-    - name: Upload-Markdown
-      uses: actions/upload-artifact@v4
-      with:
-          name: qlcplus-docs-en-markdown
-          path: ./.github/workflows/bin/markdown/
+      - name: Upload-PDF
+        uses: actions/upload-artifact@v4
+        with:
+            name: qlcplus-docs-en-pdf
+            path: ./.github/workflows/bin/pdf/
+  
+      - name: Upload-Markdown
+        uses: actions/upload-artifact@v4
+        with:
+            name: qlcplus-docs-en-markdown
+            path: ./.github/workflows/bin/markdown/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,104 +33,13 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Install PowerShell
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y powershell
-
-      - name: Create output paths
-        run: |
-          mkdir -p ./.github/workflows/bin/temp
-          mkdir -p ./.github/workflows/bin/markdown
-          mkdir -p ./.github/workflows/bin/html
-          mkdir -p ./.github/workflows/bin/pdf
-
-      - name: Run PowerShell script
-        shell: pwsh
-        run: |
-            ./scripts/Merge-MarkdownFiles.ps1
-
-      - name: Fix logo
-        run: |
-          sed -i '/!\[\](images\/qlcplus\.svg)/d'  ./.github/workflows/bin/markdown/qlcplus-docs.md 
-
-      - name: Install ImageMagick for image normalization
-        run: sudo apt-get install -y imagemagick
-  
-      - name: Normalize image DPI
-        run: |
-          for file in ./images/*.{jpg,jpeg,png,tiff,bmp}; do
-            if [[ -f "$file" ]]; then
-              convert "$file" -units PixelsPerInch -density 96 "$file"
-              echo "Processed $file"
-            fi
-          done
-
-      - name: Install GitHub CLI
-        run: sudo apt-get install gh
-
-      - name: Fetch Latest Release
-        id: get_release
-        env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Set the token for GitHub CLI authentication
-        run: |
-            RELEASE=$(gh release view --json tagName --jq .tagName)
-            echo "LATEST_RELEASE=$RELEASE" >> $GITHUB_ENV
-
-      - name: Put current date into a variable
-        run: |
-          echo "EXPORT_DATE=$(date --rfc-3339=date)" >> ${GITHUB_ENV}
-    
-      - name: Build PDF
-        uses: docker://pandoc/extra
+      - id: build
+        uses: ./.github/actions/build-pdf
         with:
-            args: >
-              -s -o ./.github/workflows/bin/temp/QLCplusDocumentation.pdf
-              ./.github/workflows/bin/markdown/qlcplus-docs.md 
-              --listings 
-              --pdf-engine=lualatex
-              -V papersize=a4 
-              -V geometry:margin=1.5cm
-              -V classoption=oneside 
-              -V indent=false
-              -V toc=true
-              -V toc-title="Table of Contents"
-              -V mainfont="Source Sans Pro"
-              -V sansfont="Source Sans Pro"
-              -f markdown-raw_tex 
-  
-      - name: Create Title Page Markdown
-        run: |
-                echo '![​](images/qlcplus.svg){ style="width: 50%; margin: auto;" }'  >>  ./.github/workflows/bin/temp/titlepage.md
-              
-      - name: Convert Title Page to PDF
-        uses: docker://pandoc/extra
-        with:
-            args: >
-                  -s -o ./.github/workflows/bin/temp/titlepage.pdf 
-                  ./.github/workflows/bin/temp/titlepage.md 
-                  --pdf-engine=lualatex
-                  --template=./scripts/template.tex
-                  --verbose
-                  -V mainfont="Source Sans Pro"
-                  -V sansfont="Source Sans Pro"
-                  -V title="Q Light Controller + Documentation"
-                  -V subtitle="Comprehensive Guide"
-                  -V author="docs.qlcplus.org"
-                  -V date="${{env.EXPORT_DATE}}"
-                  -V release="${{env.LATEST_RELEASE}}"
-                
-      - name: Combine Title Page and Documentation PDFs
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ghostscript
-          gs -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=./.github/workflows/bin/pdf/qlcplus-docs.pdf ./.github/workflows/bin/temp/titlepage.pdf ./.github/workflows/bin/temp/QLCplusDocumentation.pdf
-          echo "rm -d /.github/workflows/bin/temp/"
-    
+          lang: en
 
       - name: Upload PDF asset to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ steps.set_version.outputs.version }}" \
-            ./.github/workflows/bin/pdf/qlcplus-docs.pdf --clobber
+          gh release upload "${{ steps.set_version.outputs.version }}" "${{ steps.build.outputs.pdf_path }}" --clobber


### PR DESCRIPTION
This allows the same logic to be shared by actions triggered for releases specifically as well as on pull request or manual generation. 

Closes #78 