### PR TITLE
Add: GitHub actions support for translated documentation.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: spellcheck
+name: documentation
 on:
   push:
   pull_request:
@@ -14,8 +14,27 @@ jobs:
           config_path: .spellcheck.yml
           task_name: Markdown
 
-  build-pdf:
+  detect-langs:
     runs-on: ubuntu-latest
+    outputs:
+      langs: ${{ steps.setlangs.outputs.langs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - id: setlangs
+        run: |
+          langs=$(find pages -name '*_??.md' | sed -n 's/.*_\([A-Za-z][A-Za-z]\)\.md/\1/p' | tr '[:upper:]' '[:lower:]' | sort -u)
+          langs="en $langs"
+          json=$(printf '%s\n' $langs | jq -R . | jq -sc .)
+          echo "langs=$json" >> "$GITHUB_OUTPUT"
+
+  build-pdf:
+    needs: detect-langs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: ${{ fromJson(needs.detect-langs.outputs.langs) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,16 +42,16 @@ jobs:
       - id: build
         uses: ./.github/actions/build-pdf
         with:
-          lang: en
+          lang: ${{ matrix.lang }}
 
       - name: Upload-PDF
         uses: actions/upload-artifact@v4
         with:
-            name: qlcplus-docs-en-pdf
+            name: qlcplus-docs-${{ matrix.lang }}-pdf
             path: ./.github/workflows/bin/pdf/
-  
+
       - name: Upload-Markdown
         uses: actions/upload-artifact@v4
         with:
-            name: qlcplus-docs-en-markdown
+            name: qlcplus-docs-${{ matrix.lang }}-markdown
             path: ./.github/workflows/bin/markdown/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,8 @@ jobs:
             name: qlcplus-docs-${{ matrix.lang }}-pdf
             path: ./.github/workflows/bin/pdf/
 
-      - name: Upload-Markdown
-        uses: actions/upload-artifact@v4
-        with:
-            name: qlcplus-docs-${{ matrix.lang }}-markdown
-            path: ./.github/workflows/bin/markdown/
+#      - name: Upload-Markdown
+#        uses: actions/upload-artifact@v4
+#        with:
+#            name: qlcplus-docs-${{ matrix.lang }}-markdown
+#            path: ./.github/workflows/bin/markdown/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,28 @@ permissions:
   contents: write
       
 jobs:
+  detect-langs:
+    runs-on: ubuntu-latest
+    outputs:
+      langs: ${{ steps.setlangs.outputs.langs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - id: setlangs
+        run: |
+          langs=$(find pages -name '*_??.md' | sed -n 's/.*_\([A-Za-z][A-Za-z]\)\.md/\1/p' | tr '[:upper:]' '[:lower:]' | sort -u)
+          langs="en $langs"
+          json=$(printf '%s\n' $langs | jq -R . | jq -sc .)
+          echo "langs=$json" >> "$GITHUB_OUTPUT"
+
   build_release:
+    needs: detect-langs
     name: build_release
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: ${{ fromJson(needs.detect-langs.outputs.langs) }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -36,7 +55,7 @@ jobs:
       - id: build
         uses: ./.github/actions/build-pdf
         with:
-          lang: en
+          lang: ${{ matrix.lang }}
 
       - name: Upload PDF asset to release
         env:

--- a/pages/10.fixture-definition-editor/chapter.v4_de.md
+++ b/pages/10.fixture-definition-editor/chapter.v4_de.md
@@ -18,7 +18,7 @@ Um Ihre Fixture-Definitionen in QLC+ zu verwenden, müssen Sie sie an einem Ort 
 1. Im selben Ordner wie Ihr QLC+-Arbeitsbereich (praktisch, wenn Sie Ihren Arbeitsbereich jemand anderem geben möchten)
 2. Im Benutzer-Fixtures-Ordner an folgenden Orten:
     * Linux: Es handelt sich um einen versteckten Ordner in Ihrem Benutzer-Home-Verzeichnis: „$HOME/.qlcplus/Fixtures“.
-    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: „C:\\Benutzer\{Benutzername}\QLC+\Fixtures“.
+    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: `C:\Benutzer\{Benutzername}\QLC+\Fixtures`.
     * Mac OS: Es befindet sich in Ihrem Benutzerbibliotheksverzeichnis: „$HOME/Library/Application\\ Support/QLC+/Fixtures“.
 	
 **Wichtiger Hinweis: Sie sollten Ihre benutzerdefinierten Geräte NICHT im Geräteordner des QLC+-Systems speichern oder kopieren. Dies liegt daran, dass bei der Deinstallation von QLC+ alle Geräte in diesem Ordner gelöscht werden. Es kann auch zu unbeabsichtigten Konflikten zwischen dem System und Ihren eigenen Gerätedefinitionen kommen.**

--- a/pages/10.fixture-definition-editor/chapter.v4_de.md
+++ b/pages/10.fixture-definition-editor/chapter.v4_de.md
@@ -18,7 +18,7 @@ Um Ihre Fixture-Definitionen in QLC+ zu verwenden, müssen Sie sie an einem Ort 
 1. Im selben Ordner wie Ihr QLC+-Arbeitsbereich (praktisch, wenn Sie Ihren Arbeitsbereich jemand anderem geben möchten)
 2. Im Benutzer-Fixtures-Ordner an folgenden Orten:
     * Linux: Es handelt sich um einen versteckten Ordner in Ihrem Benutzer-Home-Verzeichnis: „$HOME/.qlcplus/Fixtures“.
-    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: `C:\Benutzer\<Benutzername>\QLC+\Fixtures`.
+    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: `C:\\Benutzer\\<Benutzername>\\QLC+\\Fixtures`.
     * Mac OS: Es befindet sich in Ihrem Benutzerbibliotheksverzeichnis: „$HOME/Library/Application\\ Support/QLC+/Fixtures“.
 	
 **Wichtiger Hinweis: Sie sollten Ihre benutzerdefinierten Geräte NICHT im Geräteordner des QLC+-Systems speichern oder kopieren. Dies liegt daran, dass bei der Deinstallation von QLC+ alle Geräte in diesem Ordner gelöscht werden. Es kann auch zu unbeabsichtigten Konflikten zwischen dem System und Ihren eigenen Gerätedefinitionen kommen.**

--- a/pages/10.fixture-definition-editor/chapter.v4_de.md
+++ b/pages/10.fixture-definition-editor/chapter.v4_de.md
@@ -18,7 +18,7 @@ Um Ihre Fixture-Definitionen in QLC+ zu verwenden, müssen Sie sie an einem Ort 
 1. Im selben Ordner wie Ihr QLC+-Arbeitsbereich (praktisch, wenn Sie Ihren Arbeitsbereich jemand anderem geben möchten)
 2. Im Benutzer-Fixtures-Ordner an folgenden Orten:
     * Linux: Es handelt sich um einen versteckten Ordner in Ihrem Benutzer-Home-Verzeichnis: „$HOME/.qlcplus/Fixtures“.
-    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: `C:\Benutzer\{Benutzername}\QLC+\Fixtures`.
+    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: `C:\Benutzer\<Benutzername>\QLC+\Fixtures`.
     * Mac OS: Es befindet sich in Ihrem Benutzerbibliotheksverzeichnis: „$HOME/Library/Application\\ Support/QLC+/Fixtures“.
 	
 **Wichtiger Hinweis: Sie sollten Ihre benutzerdefinierten Geräte NICHT im Geräteordner des QLC+-Systems speichern oder kopieren. Dies liegt daran, dass bei der Deinstallation von QLC+ alle Geräte in diesem Ordner gelöscht werden. Es kann auch zu unbeabsichtigten Konflikten zwischen dem System und Ihren eigenen Gerätedefinitionen kommen.**

--- a/pages/11.advanced/05.custom-ui-style/default.v4_de.md
+++ b/pages/11.advanced/05.custom-ui-style/default.v4_de.md
@@ -13,7 +13,7 @@ Der Dateiname ist in QLC+ fest codiert und muss lauten: „qlcplusStyle.qss“.
 Die Stildatei muss außerdem in einem bestimmten Pfad abgelegt werden:  
 
 * **Linux**: `$HOME/.qlcplus`
-* **Windows**: „C:\\Benutzer\{Benutzername}\QLC+“.
+* **Windows**: `C:\Benutzer\{Benutzername}\QLC+`.
 * **OSX**: `$HOME/Library/Application\\ Support/QLC+`
 
 Die Theme-Datei ist in Abschnitte unterteilt. Jeder Abschnitt stellt die UI-Elemente dar, die beim Ausführen von QLC+ geändert werden. Unveränderte Abschnitte können weggelassen werden.  

--- a/pages/11.advanced/05.custom-ui-style/default.v4_de.md
+++ b/pages/11.advanced/05.custom-ui-style/default.v4_de.md
@@ -13,7 +13,7 @@ Der Dateiname ist in QLC+ fest codiert und muss lauten: „qlcplusStyle.qss“.
 Die Stildatei muss außerdem in einem bestimmten Pfad abgelegt werden:  
 
 * **Linux**: `$HOME/.qlcplus`
-* **Windows**: `C:\Benutzer\<Benutzername>\QLC+`.
+* **Windows**: `C:\\Benutzer\\<Benutzername>\\QLC+`.
 * **OSX**: `$HOME/Library/Application\\ Support/QLC+`
 
 Die Theme-Datei ist in Abschnitte unterteilt. Jeder Abschnitt stellt die UI-Elemente dar, die beim Ausführen von QLC+ geändert werden. Unveränderte Abschnitte können weggelassen werden.  

--- a/pages/11.advanced/05.custom-ui-style/default.v4_de.md
+++ b/pages/11.advanced/05.custom-ui-style/default.v4_de.md
@@ -13,7 +13,7 @@ Der Dateiname ist in QLC+ fest codiert und muss lauten: „qlcplusStyle.qss“.
 Die Stildatei muss außerdem in einem bestimmten Pfad abgelegt werden:  
 
 * **Linux**: `$HOME/.qlcplus`
-* **Windows**: `C:\Benutzer\{Benutzername}\QLC+`.
+* **Windows**: `C:\Benutzer\<Benutzername>\QLC+`.
 * **OSX**: `$HOME/Library/Application\\ Support/QLC+`
 
 Die Theme-Datei ist in Abschnitte unterteilt. Jeder Abschnitt stellt die UI-Elemente dar, die beim Ausführen von QLC+ geändert werden. Unveränderte Abschnitte können weggelassen werden.  

--- a/scripts/Merge-MarkdownFiles.ps1
+++ b/scripts/Merge-MarkdownFiles.ps1
@@ -1,5 +1,5 @@
-param([string]$Lang="EN")
-$Lang = $Lang.ToUpper()
+param([string]$Lang="en")
+$Lang = $Lang.ToLower()
 
 function Update-MarkdownHeadingLevels {
     param (


### PR DESCRIPTION
This pull request allows our documentation translations to be transformed into individual PDFs.

I now call the build-pdf action from main.yml and release.yaml in a matrix where it is passed each language code.

New functionality:
-  Auto-detect available languages for PDF build matrix
-  Run PDF builds for each detected language in both main and release workflows

What was required:
- Handling uppercase codes in the powershell script
- Modification to the DE version windows paths as they tricked Pandoc into thinking they were LATEX commands

Future plans:
- The title page will need to handle different languages. Some basic translation strings should work well for this.
- Ideally we should consider moving away from powershell but eh it works

I wanted to raise this PR before going into the weeds with the title page to check you're okay with everything so far @mcallegari 
