### PR TITLE
Add separate language dropdown (closes #32)

### DIFF
--- a/themes/mytheme/css/custom.css
+++ b/themes/mytheme/css/custom.css
@@ -35,3 +35,13 @@ Put your custom CSS in this file.
     height: 30px;
     padding: 0 7px 0 10px;
 }
+
+.language-chooser select {
+    font-weight: 700;
+    color: #fff;
+    background: #1383b3;
+    border: 1px solid #19a5e1;
+    border-radius: 0.1875rem;
+    height: 30px;
+    padding: 0 7px 0 10px;
+}

--- a/themes/mytheme/templates/partials/versions.html.twig
+++ b/themes/mytheme/templates/partials/versions.html.twig
@@ -1,8 +1,23 @@
+{% set langobj = grav['language'] %}
+{# Build a map of versions to languages #}
+{% set versions = {} %}
+{% for key in langswitcher.languages %}
+    {% set parts = key|split('_') %}
+    {% set ver = parts[0] %}
+    {% set lang = parts|length > 1 ? parts[1] : 'en' %}
+    {% set versions = versions|merge({ (ver):(versions[ver]|default([]))|merge([lang]) }) %}
+{% endfor %}
+
+{% set current_parts = langswitcher.current|split('_') %}
+{% set current_version = current_parts[0] %}
+{% set current_language = current_parts|length > 1 ? current_parts[1] : 'en' %}
+
 <div class="version-chooser">
   Version:
     <select id="switch-version">
-    {% set langobj = grav['language'] %}
-    {% for key in langswitcher.languages %}
+    {% for ver in versions|keys %}
+        {% set target_lang = current_language in versions[ver] ? current_language : 'en' %}
+        {% set key = ver ~ (target_lang == 'en' ? '' : '_' ~ target_lang) %}
         {% if key == langswitcher.current %}
             {% set lang_url = page.url %}
             {% set active = ' selected="selected"' %}
@@ -10,10 +25,29 @@
             {% set lang_url = base_url_simple ~ langobj.getLanguageURLPrefix(key)~langswitcher.page_route ?: '/' %}
             {% set active = '' %}
         {% endif %}
-        <option value="{{ lang_url ~ uri.params }}"{{ active }}>{{ key }}</option>
+        <option value="{{ lang_url ~ uri.params }}"{{ active }}>{{ ver }}</option>
     {% endfor %}
     </select>
 </div>
+
+<div class="language-chooser">
+  Language:
+    <select id="switch-language">
+    {% for lang in versions[current_version]|default(['en']) %}
+        {% set key = current_version ~ (lang == 'en' ? '' : '_' ~ lang) %}
+        {% if key == langswitcher.current %}
+            {% set lang_url = page.url %}
+            {% set active = ' selected="selected"' %}
+        {% else %}
+            {% set lang_url = base_url_simple ~ langobj.getLanguageURLPrefix(key)~langswitcher.page_route ?: '/' %}
+            {% set active = '' %}
+        {% endif %}
+        <option value="{{ lang_url ~ uri.params }}"{{ active }}>{{ lang }}</option>
+    {% endfor %}
+    </select>
+</div>
+
 <script>
 jQuery(document).on('change', '#switch-version', function() { window.location.href = this.value });
+jQuery(document).on('change', '#switch-language', function() { window.location.href = this.value });
 </script>


### PR DESCRIPTION
This pull request aims to enable more intuitive language selection on the docs.qlcplus.org website. 

It adds a second drop-down, separate to the version which allows the language to be selected. 

Why? The [Grav devs don't have a better way.](https://github.com/getgrav/grav/issues/3893)

Closes #32 In mcallegari/qlcplus-docs;