### PR TITLE
README: update link to user manual PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
         <img src="https://img.shields.io/badge/View_Online-grey?style=for-the-badge&logo=aiohttp
         " /></a>
     <!-- BEGIN LATEST DOWNLOAD BUTTON -->
-    <a href="https://www.qlcplus.org/downloads/4.14.0/QLC+_4.14.0_user_manual.pdf" alt="offline-pdf">
+    <a href="https://www.qlcplus.org/downloads/4.14.3/QLC+_4.14.3_user_manual.pdf" alt="offline-pdf">
         <img src="https://custom-icon-badges.demolab.com/badge/-Download_PDF-blue?style=for-the-badge&logo=download&logoColor=white" /></a>
     <!-- END LATEST DOWNLOAD BUTTON -->
 </p>


### PR DESCRIPTION
Or maybe change it to https://github.com/mcallegari/qlcplus-docs/releases/latest/download/qlcplus-docs.pdf, which always automatically links to the PDF attached to the latest release version tagged on GitHub?