### PR TITLE
Restore incorrectly deleted newlines

### DIFF
--- a/pages/01.basics/04.glossary-and-concepts/default.v4_de.md
+++ b/pages/01.basics/04.glossary-and-concepts/default.v4_de.md
@@ -9,10 +9,10 @@ Diese Seite wurde in alphabetischer Reihenfolge geordnet, um die Suche nach eine
 
 ### ![](../audio.png) Audio
 
-Eine Audio-[Funktion](#funktionen) ist ein Objekt, das eine auf einer Festplatte gespeicherte Audiodatei darstellt.
-QLC+ unterstützt die gängigsten Audioformate wie Wave, MP3, M4A, Ogg und Flac. Es unterstützt Mono- oder Stereokanäle und verschiedene Abtastraten wie 44,1 kHz, 48 kHz usw.
-Audiofunktionen können mithilfe des Bedienfelds [Show Manager](/show-manager) zum gewünschten Zeitpunkt im [Chaser](#chaser) oder in einer [Show](#show) platziert werden.
-Wie die meisten QLC+ Funktionen unterstützt Audio Ein- und Ausblendzeiten.
+Eine Audio-[Funktion](#funktionen) ist ein Objekt, das eine auf einer Festplatte gespeicherte Audiodatei darstellt.  
+QLC+ unterstützt die gängigsten Audioformate wie Wave, MP3, M4A, Ogg und Flac. Es unterstützt Mono- oder Stereokanäle und verschiedene Abtastraten wie 44,1 kHz, 48 kHz usw.  
+Audiofunktionen können mithilfe des Bedienfelds [Show Manager](/show-manager) zum gewünschten Zeitpunkt im [Chaser](#chaser) oder in einer [Show](#show) platziert werden.  
+Wie die meisten QLC+-Funktionen unterstützt Audio Ein- und Ausblendzeiten.
 
 ### ![](../blackout.png) Blackout
 
@@ -28,7 +28,7 @@ Einige Kanäle in intelligenten Geräten bieten viele Arten von Funktionen oder 
 
 ### Kanalgruppen
 
-Kanalgruppen können im Bereich [Fixture Manager](/fixture-manager) mithilfe des [Channel Groups Editor](/fixture-manager/channel-groups-editor) hinzugefügt und definiert werden.
+Kanalgruppen können im Bereich [Fixture Manager](/fixture-manager) mithilfe des [Channel Groups Editor](/fixture-manager/channel-groups-editor) hinzugefügt und definiert werden.  
 Kanalgruppen können einen benutzerdefinierten Namen haben und alle benutzerdefinierten Kanäle gruppieren, die aus einer vorhandenen Geräteliste ausgewählt werden.
 
 ### ![](../chaser.png) Chaser
@@ -48,7 +48,7 @@ Kopien von Chaserfunktionen können mit dem [Funktionsmanager](/function-manager
 
 ### Click And Go
 
-Click And Go ist eine Technologie, die es dem Benutzer ermöglicht auf vollständig visuelle Weise und mit nur wenigen Klicks schnell auf Makros und Farben zuzugreifen. Dies kann zu effizienteren Live-Shows und mehr Freiheit bei der Auswahl des gewünschten Ergebnisses führen.
+Click And Go ist eine Technologie, die es dem Benutzer ermöglicht auf vollständig visuelle Weise und mit nur wenigen Klicks schnell auf Makros und Farben zuzugreifen. Dies kann zu effizienteren Live-Shows und mehr Freiheit bei der Auswahl des gewünschten Ergebnisses führen.  
 Bisher sind drei Arten von Widgets verfügbar:
 
 * Einzelne Farbe (gilt für die Intensitätskanäle Rot, Grün, Blau, Cyan, Gelb, Magenta, Amber und Weiß)
@@ -162,9 +162,9 @@ Eine Überblendung zwischen zwei [Szenen](#szene) ersetzt die HTP-Pegel in der e
 
 ### ![](../input_output.png) Eingabe-/Ausgabe-Plugins
 
-QLC+ unterstützt eine Vielzahl von Plugins zum Senden und Empfangen von Daten von/an die DMX Universen und Art-Net Controller.
-Ein Plugin kann eine Schnittstelle zu physischen Geräten (z. B. DMX-Adaptern oder MIDI-Controllern) oder zu einem Netzwerkprotokoll (z. B. [ArtNet](/plugins/art-net), [OSC](/plugins/osc) oder [E1.31](/plugins/e1-31-sacn)).
-Plugins unterstützen Eingabe-, Ausgabe- oder Feedbackfunktionen abhängig vom Gerät oder Protokoll das sie steuern.
+QLC+ unterstützt eine Vielzahl von Plugins zum Senden und Empfangen von Daten von/an die DMX Universen und Art-Net Controller.  
+Ein Plugin kann eine Schnittstelle zu physischen Geräten (z. B. DMX-Adaptern oder MIDI-Controllern) oder zu einem Netzwerkprotokoll (z.B. [ArtNet](/plugins/art-net), [OSC](/plugins/osc) oder [E1.31](/plugins/e1-31-sacn)) sein.  
+Plugins unterstützen Eingabe-, Ausgabe- oder Feedbackfunktionen abhängig vom Gerät oder Protokoll das sie steuern.  
 
 Die primären Eingabemethoden für QLC+ sind natürlich die Tastatur und Maus. Benutzer können Tastaturtasten virtuellen Konsolentasten zuweisen, Schieberegler ziehen und so ziemlich alles mit einer Maus und Tastatur erledigen.
 
@@ -220,9 +220,9 @@ Kopien von Szenenfunktionen können mit dem [Funktionsmanager](/function-manager
 
 ### ![](../sequence.png) Sequenz
 
-Eine Sequenz verfügt über einige der Funktionen eines [Chasers](#chaser).
-Es entspricht einem Chaser, bei dem jeder Schritt eine einzelne [Szene](#szene) ist und jede dieser Szenen denselben Kanalsatz steuert. Eine Sequenz ist an eine bestimmte Szene gebunden, was bedeutet, dass alle Schritte der Sequenz nur die aktivierten Kanäle dieser Szene steuern können.
-Beim Erstellen neuer Schritte in einer Sequenz wird kein Popup zur Funktionsauswahl angezeigt, da ein Sequenzschritt im Gegensatz zu einem Chaser-Schritt keine anderen Funktionen enthalten kann.
+Eine Sequenz verfügt über einige der Funktionen eines [Chasers](#chaser).  
+Es entspricht einem Chaser, bei dem jeder Schritt eine einzelne [Szene](#szene) ist und jede dieser Szenen denselben Kanalsatz steuert. Eine Sequenz ist an eine bestimmte Szene gebunden, was bedeutet, dass alle Schritte der Sequenz nur die aktivierten Kanäle dieser Szene steuern können.  
+Beim Erstellen neuer Schritte in einer Sequenz wird kein Popup zur Funktionsauswahl angezeigt, da ein Sequenzschritt im Gegensatz zu einem Chaser-Schritt keine anderen Funktionen enthalten kann.  
 Wenn eine Sequenz erstellt wird, erscheint im [Funktionsmanager](/function-manager) ein spezielles Sequenzsymbol als untergeordnetes Element der Szene, an die es gebunden ist.
 Um den Unterschied zwischen einer Sequenz und einem Chaser zu verstehen, lesen Sie bitte den zweiten Absatz der Dokumentation zum [Show Manager](/show-manager).
 
@@ -237,6 +237,6 @@ Eine Show ist eine erweiterte [Funktion](#funktionen), die die meisten QLC+-Funk
 
 ### ![](../video.png) Video
 
-Eine Video[funktion](#funktionen) ist ein Objekt, das eine auf einer Festplatte oder einer Netzwerk-URL gespeicherte Videodatei darstellt.
-Die unterstützten Videoformate hängen von Ihrem Betriebssystem ab. Beispielsweise ist Mac OSX auf MOV/MP4-Dateien beschränkt und nicht viel mehr.
+Eine Video[funktion](#funktionen) ist ein Objekt, das eine auf einer Festplatte oder einer Netzwerk-URL gespeicherte Videodatei darstellt.  
+Die unterstützten Videoformate hängen von Ihrem Betriebssystem ab. Beispielsweise ist Mac OSX auf MOV/MP4-Dateien beschränkt und nicht viel mehr.  
 Videofunktionen können mithilfe des Bedienfelds [Show Manager](/show-manager) zum gewünschten Zeitpunkt in [Chaser](#chaser) oder in einer [Show](#show) platziert werden.

--- a/pages/01.basics/05.questions-and-answers/default.v4_de.md
+++ b/pages/01.basics/05.questions-and-answers/default.v4_de.md
@@ -4,7 +4,7 @@ date: '08:32 21-08-2023'
 media_order: dmx-usb-settings.png
 ---
 
-Auf dieser Seite finden Sie die häufigsten Fragen, die Ihnen beim Einstieg in QLC+ in den Sinn kommen könnten.
+Auf dieser Seite finden Sie die häufigsten Fragen, die Ihnen beim Einstieg in QLC+ in den Sinn kommen könnten.  
 Hier finden Sie entweder direkt die Antwort oder Hilfe, die Ihnen den richtigen Weg weist.
 
 

--- a/pages/02.main-window/01.dmx-monitor/docs.v4_de.md
+++ b/pages/02.main-window/01.dmx-monitor/docs.v4_de.md
@@ -9,10 +9,10 @@ process:
 media_order: pan-tilt.png
 ---
 
-Der DMX-Monitor ist ein nützliches Tool zum Verfolgen der Werte, die an die Ausgabeuniversen gesendet werden. Es werden nur die Informationen zu den benötigten Vorrichtungen angezeigt. Die Anzeigeoptionen des Monitors haben keinen Einfluss auf die eigentliche Geräteadressierung, schließlich handelt es sich nur um einen **Monitor**.
+Der DMX-Monitor ist ein nützliches Tool zum Verfolgen der Werte, die an die Ausgabeuniversen gesendet werden. Es werden nur die Informationen zu den benötigten Vorrichtungen angezeigt. Die Anzeigeoptionen des Monitors haben keinen Einfluss auf die eigentliche Geräteadressierung, schließlich handelt es sich nur um einen **Monitor**.  
 Der DMX-Monitor verfügt über zwei Anzeigemodi: **DMX-Ansicht** und **2D-Ansicht**.
 
-DMX Ansicht
+DMX-Ansicht
 --------
 
 Die DMX-Ansicht zeigt alle Geräte des Projekts und spiegelt jeden Kanal mit Zahlen und Symbolen dar. Es stellt grundsätzlich jeden Kanal in 3 Zeilen dar:
@@ -46,8 +46,8 @@ Derzeit zeigt der Monitor Folgendes an:
 * Farbräder, wenn sie RGB-Farbwerte enthalten. Zweifarbige Werte werden nicht unterstützt
 * Shutter, der geöffnet ist, es sei denn, der Funktionsname enthält „close“ oder „blackout“ (Beispiel: „Shutter Close“)
 
-Im 2D-Ansichtsmodus können Sie auswählen, welche Geräte angezeigt werden sollen, sowie deren Position in einem Raster, das die Abmessungen einer realen Bühne darstellt.
-Das Raster möchte die Vorderansicht einer Bühne reproduzieren, Sie können es jedoch nach Belieben als generischen Raum verwenden.
+Im 2D-Ansichtsmodus können Sie auswählen, welche Geräte angezeigt werden sollen, sowie deren Position in einem Raster, das die Abmessungen einer realen Bühne darstellt.  
+Das Raster möchte die Vorderansicht einer Bühne reproduzieren, Sie können es jedoch nach Belieben als generischen Raum verwenden.  
 Grafische Elemente können manuell verschoben werden, indem Sie sie über das Raster ziehen. Wenn Sie darauf klicken, können Sie sie mit dem Bedienfeld „Monitor Fixture Editor“ konfigurieren, das auf der rechten Seite des Fensters angezeigt wird.
 
 ### Symbolleisten-Steuerelemente
@@ -64,7 +64,7 @@ Grafische Elemente können manuell verschoben werden, indem Sie sie über das Ra
 
 ### Fixture Item Editor
 
-Wenn auf ein Gerät geklickt wird, wird es gelb hervorgehoben und der Monitor Fixture Item Editor wird auf der rechten Seite des Fensters angezeigt.
+Wenn auf ein Gerät geklickt wird, wird es gelb hervorgehoben und der Monitor Fixture Item Editor wird auf der rechten Seite des Fensters angezeigt.  
 Im Folgenden sind die möglichen Parameter aufgeführt, die angepasst werden können:
 
 | | |

--- a/pages/02.main-window/02.dmx-address-tool/docs.v4_de.md
+++ b/pages/02.main-window/02.dmx-address-tool/docs.v4_de.md
@@ -5,8 +5,8 @@ taxonomy:
         - docs
 ---
 
-Das DMX-Adresstool ist eine recht einfache/selbsterklärende Funktionalität von QLC+, die in Version 4.3.2 eingeführt wurde.
-Es hilft Ihnen, die Adressen Ihrer Geräte schnell und visuell zu berechnen.
+Das DMX-Adresstool ist eine recht einfache/selbsterklärende Funktionalität von QLC+, die in Version 4.3.2 eingeführt wurde.  
+Es hilft Ihnen, die Adressen Ihrer Geräte schnell und visuell zu berechnen.  
 Es wird eine Darstellung eines herkömmlichen 10-Wege-DIP-Schalters angezeigt und Sie können die Hintergrundfarbe sowie die horizontale und vertikale Ausrichtung auswählen, sodass der DIP-Schalter genau so angezeigt wird, wie Sie ihn auf Ihrem Gerät sehen würden.
 
 Beachten Sie, dass bei vielen Geräten Schalter 10 zum Aktivieren oder Deaktivieren des DMX-Eingangs verwendet wird. Wenn in Ihrem Produkthandbuch angegeben ist, dass es „ein“ sein muss, um den DMX-Eingang zu aktivieren, denken Sie daran, dies zu tun, auch wenn QLC+ auf AUS eingestellt ist.

--- a/pages/02.main-window/03.dmx-dump/docs.v4_de.md
+++ b/pages/02.main-window/03.dmx-dump/docs.v4_de.md
@@ -5,8 +5,8 @@ taxonomy:
         - docs
 ---
 
-Mit der DMX-Dump-Funktion können Sie die aktuellen DMX-Werte speichern, die zu einem bestimmten Zeitpunkt an die Ausgabeuniversen gesendet werden. Grundsätzlich wird ein „Schnappschuss“ der DMX-Kanäle erstellt und für eine spätere Verwendung gespeichert.
-DMX Dump kann Werte in einer neuen [Szene](/basics/glossary-and-concepts#szene) speichern oder die Werte einer vorhandenen Szene überschreiben. Die „gedumpte“ Szene kann auch zu einem vorhandenen [Chaser](/basics/glossary-and-concepts#chaser), einer [Schaltfläche](/virtual-console/button) oder einem [Schieberegler](/virtual-console/slider) einer virtuellen Konsole hinzugefügt werden)
+Mit der DMX-Dump-Funktion können Sie die aktuellen DMX-Werte speichern, die zu einem bestimmten Zeitpunkt an die Ausgabeuniversen gesendet werden. Grundsätzlich wird ein „Schnappschuss“ der DMX-Kanäle erstellt und für eine spätere Verwendung gespeichert.  
+DMX Dump kann Werte in einer neuen [Szene](/basics/glossary-and-concepts#szene) speichern oder die Werte einer vorhandenen Szene überschreiben. Die „gedumpte“ Szene kann auch zu einem vorhandenen [Chaser](/basics/glossary-and-concepts#chaser), einer [Schaltfläche](/virtual-console/button) oder einem [Schieberegler](/virtual-console/slider) einer virtuellen Konsole hinzugefügt werden.  
 
 Bitte beachten Sie Folgendes:
 

--- a/pages/02.main-window/04.live-edit/docs.v4_de.md
+++ b/pages/02.main-window/04.live-edit/docs.v4_de.md
@@ -5,19 +5,19 @@ taxonomy:
         - docs
 ---
 
-Ab Version 4.5.0 bietet QLC+ eine Funktionalität, die die Anpassung Ihrer [Funktionen](/basics/glossary-and-concepts#funktionen) im [Betriebsmodus](/basics/glossary-and-concepts#modi) ermöglicht.
-Das Live Edit-Symbol ![](/basics/liveedit.png) befindet sich in der oberen Leiste von QLC+ neben dem [DMX Dump](/main-window/dmx-dump)-Symbol ![](/basics/add_dump.png) und Es wird erst aktiviert, wenn der Benutzer in den Betriebsmodus gewechselt hat.
-Wenn Sie auf das Live-Edit-Symbol klicken, wird ein Bereich [Funktionsauswahl](/function-manager/function-selection) angezeigt, in dem Sie die Funktion auswählen können, die Sie anpassen möchten.
-Wenn Sie OK drücken, wird der richtige Editor zum Bearbeiten dieser Funktion angezeigt.
+Ab Version 4.5.0 bietet QLC+ eine Funktionalität, die die Anpassung Ihrer [Funktionen](/basics/glossary-and-concepts#funktionen) im [Betriebsmodus](/basics/glossary-and-concepts#modi) ermöglicht.  
+Das Live Edit-Symbol ![](/basics/liveedit.png) befindet sich in der oberen Leiste von QLC+ neben dem [DMX Dump](/main-window/dmx-dump)-Symbol ![](/basics/add_dump.png) und Es wird erst aktiviert, wenn der Benutzer in den Betriebsmodus gewechselt hat.  
+Wenn Sie auf das Live-Edit-Symbol klicken, wird ein Bereich [Funktionsauswahl](/function-manager/function-selection) angezeigt, in dem Sie die Funktion auswählen können, die Sie anpassen möchten.  
+Wenn Sie OK drücken, wird der richtige Editor zum Bearbeiten dieser Funktion angezeigt.  
 Derzeit werden folgende Funktionen für die Live-Bearbeitung unterstützt:
 
-* ![](/basics/scene.png) [Szene](/basics/glossary-and-concepts#szene) öffnet einen [Szeneneditor](/function-manager/scene-editor)
+* ![](/basics/scene.png) [Szene](/basics/glossary-and-concepts#szene) öffnet einen [Szeneneditor](/function-manager/scene-editor)  
     Beachten Sie, dass sich der Editor standardmäßig im „Blind-Modus“ befindet, wenn Sie eine Szene bearbeiten, die gerade nicht läuft, falls Sie die Änderungen erst wirksam machen möchten, wenn die Szene das nächste Mal ausgewählt wird. Für eine aktuell laufende Szene wird der Editor standardmäßig im Live-Modus geöffnet.
 * ![](/basics/chaser.png) [Chaser](/basics/glossary-and-concepts#chaser) öffnet einen [Chaser-Editor](/function-manager/chaser-editor)
 * ![](/basics/efx.png) [EFX](/basics/glossary-and-concepts#efx) öffnet einen [EFX-Editor](/function-manager/efx-editor)
 * ![](/basics/rgbmatrix.png) [RGB-Matrix](/basics/glossary-and-concepts#rgb-matrix) öffnet einen [RGB-Matrix-Editor](/function-manager/rgb-matrix-editor)
 
-    Die in der [Funktionsauswahl](/function-manager/function-selection) aufgeführten Funktionstypen können mithilfe der Filter-Kontrollkästchen am unteren Rand des Bedienfelds ausgewählt werden.
-    Oben im Bedienfeld gibt es eine Option, um nur die aktuell ausgeführten Funktionen aufzulisten.
+    Die in der [Funktionsauswahl](/function-manager/function-selection) aufgeführten Funktionstypen können mithilfe der Filter-Kontrollkästchen am unteren Rand des Bedienfelds ausgewählt werden.  
+    Oben im Bedienfeld gibt es eine Option, um nur die aktuell ausgeführten Funktionen aufzulisten.  
 
     Beachten Sie, dass, wenn während einer Live-Bearbeitung eine andere Funktion ausgeführt wird, HTP-Kanäle in der anderen Funktion möglicherweise verhindern, dass einige Anpassungen auf der Bühne sichtbar sind.

--- a/pages/02.main-window/chapter.v4_de.md
+++ b/pages/02.main-window/chapter.v4_de.md
@@ -32,45 +32,30 @@ Die Menüleiste oben im Arbeitsbereichsfenster enthält die folgenden Schaltflä
 
 * * *
 
-![](../basics/filenew.png) Neuer Arbeitsbereich (STRG+N)
-
-![](../basics/fileopen.png) Öffnen Sie einen vorhandenen Arbeitsbereich (halten Sie die Taste länger gedrückt, um eine Liste der zuletzt verwendeten Dateien anzuzeigen) (STRG+O)
-
-![](../basics/filesave.png) Aktuellen Arbeitsbereich speichern (STRG+S)
-
-![](../basics/filesaveas.png) Speichern Sie den aktuellen Arbeitsbereich unter einem neuen Namen
-
+![](../basics/filenew.png) Neuer Arbeitsbereich (STRG+N)  
+![](../basics/fileopen.png) Öffnen Sie einen vorhandenen Arbeitsbereich (halten Sie die Taste länger gedrückt, um eine Liste der zuletzt verwendeten Dateien anzuzeigen) (STRG+O)  
+![](../basics/filesave.png) Aktuellen Arbeitsbereich speichern (STRG+S)  
+![](../basics/filesaveas.png) Speichern Sie den aktuellen Arbeitsbereich unter einem neuen Namen  
 
 * * *
 
-![](../basics/monitor.png)[DMX Monitor](/main-window/dmx-monitor) (STRG+M)
-
-![](../basics/diptool.png)[DMX Address tool](/main-window/dmx-address-tool)
-
-![](../basics/audioinput.png)[Audio triggers](/virtual-console/audio-triggers)
-
+![](../basics/monitor.png)[DMX Monitor](/main-window/dmx-monitor) (STRG+M)  
+![](../basics/diptool.png)[DMX Address tool](/main-window/dmx-address-tool)  
+![](../basics/audioinput.png)[Audio triggers](/virtual-console/audio-triggers)  
 
 * * *
 
-![](../basics/fullscreen.png) Vollbildmodus umschalten (STRG+F11)
-
-![](../basics/help.png) Diese Dokumentation anzeigen (Umschalt+F1)
-
-![](../basics/qlcplus.svg?resize=32,32) Informationen zu QLC+ anzeigen
-
+![](../basics/fullscreen.png) Vollbildmodus umschalten (STRG+F11)  
+![](../basics/help.png) Diese Dokumentation anzeigen (Umschalt+F1)  
+![](../basics/qlcplus.svg?resize=32,32) Informationen zu QLC+ anzeigen  
 
 * * *
 
-![](../basics/add_dump.png)[DMX Dump](/main-window/dmx-dump) (STRG+D)
-
-![](../basics/liveedit.png)[Live Edit](/main-window/live-edit): ermöglicht Ihnen das Ändern einer Funktion, während sich QLC+ im Betriebsmodus befindet
-
-![](../basics/liveedit_vc.png) Live Edit Virtual Console: Ermöglicht Ihnen, die virtuelle Konsole zu ändern, während sich QLC+ im Betriebsmodus befindet. Klicken Sie zum Umschalten
-
-![](../basics/panic.png) Alle Funktionen stoppen (STRG+Umschalt+ESC)
-
-![](../basics/blackout.png) Blackout umschalten
-
+![](../basics/add_dump.png)[DMX Dump](/main-window/dmx-dump) (STRG+D)  
+![](../basics/liveedit.png)[Live Edit](/main-window/live-edit): ermöglicht Ihnen das Ändern einer Funktion, während sich QLC+ im Betriebsmodus befindet  
+![](../basics/liveedit_vc.png) Live Edit Virtual Console: Ermöglicht Ihnen, die virtuelle Konsole zu ändern, während sich QLC+ im Betriebsmodus befindet. Klicken Sie zum Umschalten.  
+![](../basics/panic.png) Alle Funktionen stoppen (STRG+Umschalt+ESC)  
+![](../basics/blackout.png) Blackout umschalten  
 ![](../basics/operate.png) Zwischen Entwurfsmodus und Betriebsmodus wechseln (STRG+F12)
 
 ### Aktive Kanäle (2)
@@ -83,14 +68,9 @@ Unten im Hauptfenster finden Sie auffällige Symbole zum Wechseln zwischen QLC+-
 Durch Doppelklick auf eine Registerkarte kann **ein Kontext in einem separaten Fenster gelöst werden**. Um einen getrennten Kontext wieder anzuhängen, schließen Sie einfach das Fenster.
 QLC+-Kontexte werden in der folgenden Reihenfolge angezeigt (von links nach rechts):
 
-![](../basics/fixture.png) Sehen Sie sich den [Fixture Manager](/fixture-manager) an.
-
-![](../basics/function.png) Sehen Sie sich den [Funktionsmanager](/function-manager) an.
-
-![](../basics/show.png) Den [Show Manager](/show-manager) anzeigen
-
-![](../basics/virtualconsole.png) Sehen Sie sich die [Virtuelle Konsole](/virtual-console) an.
-
-![](../basics/slidermatrix.png) Sehen Sie sich den [Simple Desk](/simple-desk) an.
-
-![](../basics/input_output.png) Sehen Sie sich den Konfigurationsmanager [Input/Output](/input-output) an.
+![](../basics/fixture.png) Sehen Sie sich den [Fixture Manager](/fixture-manager) an.  
+![](../basics/function.png) Sehen Sie sich den [Funktionsmanager](/function-manager) an.  
+![](../basics/show.png) Sehen Sie sich den [Show Manager](/show-manager) an.  
+![](../basics/virtualconsole.png) Sehen Sie sich die [Virtuelle Konsole](/virtual-console) an.  
+![](../basics/slidermatrix.png) Sehen Sie sich den [Simple Desk](/simple-desk) an.  
+![](../basics/input_output.png) Sehen Sie sich den [Eingabe-/Ausgabe](/input-output)-Konfigurationsmanager an.

--- a/pages/03.fixture-manager/02.add-rgb-panel/default.v4_de.md
+++ b/pages/03.fixture-manager/02.add-rgb-panel/default.v4_de.md
@@ -3,17 +3,17 @@ title: 'RGB Panel hinzufügen'
 date: '11:11 21-08-2023'
 ---
 
-Auf dem Markt finden Sie leicht LED-Streifen die Sie nach Belieben verdrahten können, um ein RGB-Panel (oder eine Matrix) zu erstellen. In diesem Dialogfeld können Sie schnell ein RGB-Panel erstellen und einrichten. Es handelt sich um einen speziellen Dialog, der Sie bei dem umfangreichen Prozess der manuellen Erstellung von Vorrichtungen je nach gewünschtem Layout unterstützt.
+Auf dem Markt finden Sie leicht LED-Streifen, die Sie nach Belieben verdrahten können, um ein RGB-Panel (oder eine Matrix) zu erstellen. In diesem Dialogfeld können Sie schnell ein RGB-Panel erstellen und einrichten. Es handelt sich um einen speziellen Dialog, der Sie bei dem umfangreichen Prozess der manuellen Erstellung von Vorrichtungen je nach gewünschtem Layout unterstützt.  
 Bitte beachten Sie, dass das Layout nach der Erstellung des Panels nur noch manuell geändert werden kann.
 
 ## Panel Erstellung
 
-Wenn Sie in diesem Dialogfeld auf „OK“ klicken passieren zwei Dinge:
+Wenn Sie in diesem Dialogfeld auf „OK“ klicken passieren zwei Dinge:  
 
 * QLC+ erstellt eine Vorrichtung für jede Reihe des Panels. Sie können so betrachtet werden, als ob das Panel aus einzelnen RGB-Balken zusammengesetzt wäre.
 * QLC+ erstellt eine Gerätegruppe, die das Panel mit den Köpfen darstellt, die sich bereits in der richtigen Verschiebung befinden
 
-Sobald ein RGB-Panel erstellt ist, können Sie ganz einfach zum [Funktionsmanager](/function-manager) gehen, eine neue [RGB-Matrix](/basics/glossary-and-concepts#rgb-matrix) erstellen und sehr schnell mit der Benutzung beginnen.
+Sobald ein RGB-Panel erstellt ist, können Sie ganz einfach zum [Funktionsmanager](/function-manager) gehen, eine neue [RGB-Matrix](/basics/glossary-and-concepts#rgb-matrix) erstellen und sehr schnell mit der Benutzung beginnen.  
 
 Schauen wir uns alle Optionen in diesem Bereich an:
 

--- a/pages/03.fixture-manager/04.channel-groups-editor/default.v4_de.md
+++ b/pages/03.fixture-manager/04.channel-groups-editor/default.v4_de.md
@@ -3,8 +3,8 @@ title: 'Kanalgruppen Editor'
 date: '11:27 21-08-2023'
 ---
 
-Der Kanalgruppen-Editor wird durch Klicken auf die Registerkarte „Kanalgruppen“ im Bereich [Fixture Manager](/fixture-manager) aktiviert.
-Mit dieser Funktionalität (eingeführt in QLC+ Version 4.0.0) ist es möglich, Gruppen von Kanälen mit derselben Funktionalität zu erstellen.
+Der Kanalgruppen-Editor wird durch Klicken auf die Registerkarte „Kanalgruppen“ im Bereich [Fixture Manager](/fixture-manager) aktiviert.  
+Mit dieser Funktionalität (eingeführt in QLC+ Version 4.0.0) ist es möglich, Gruppen von Kanälen mit derselben Funktionalität zu erstellen.  
 Wenn Sie beispielsweise über 20 PARs verfügen, möchten Sie möglicherweise den ROTEN Kanal aller PARs mit einem einzigen Fader steuern.
 
 ### Einstellungen

--- a/pages/03.fixture-manager/05.channel-properties/default.v4_de.md
+++ b/pages/03.fixture-manager/05.channel-properties/default.v4_de.md
@@ -4,8 +4,8 @@ date: '11:32 21-08-2023'
 media_order: channel_modifier.png
 ---
 
-Dieses Fenster zeigt einen Baum mit Elementen an, die in einer Universes/Fixtures/Channels-Struktur verschachtelt sind.
-Auf der rechten Seite des Kanals jedes Geräts werden die verfügbaren Optionen angezeigt, mit denen das Verhalten jedes einzelnen Kanals geändert werden kann.
+Dieses Fenster zeigt einen Baum mit Elementen an, die in einer Universes/Fixtures/Channels-Struktur verschachtelt sind.  
+Auf der rechten Seite des Kanals jedes Geräts werden die verfügbaren Optionen angezeigt, mit denen das Verhalten jedes einzelnen Kanals geändert werden kann.  
 
 Channels properties
 -------------------
@@ -28,15 +28,15 @@ TDer Kanalmodifikator-Editor wird wie folgt dargestellt:
 
 ![](channel_modifier.png)
 
-Auf der rechten Seite des Fensters wird eine Liste der verfügbaren Modifikatorvorlagen angezeigt.
-Durch Klicken auf eine Vorlage in der Liste wird die Kurvenvorschau auf der linken Seite des Fensters angezeigt.
-Eine Modifikatorkurve besteht aus einer Reihe von Linien, die darstellen, wie ein DMX-Kanal geändert werden soll, wenn sich sein Wert ändert.
-Jede Zeile beginnt und endet mit einem sogenannten „Handler“. Ein Modifikator kann praktisch unendlich viele Handler haben, aber es muss immer einen Handler für den DMX-Wert 0 und einen Handler für den DMX-Wert 255 geben, um den gesamten DMX-Wertebereich abzudecken.
-Grundsätzlich repräsentiert die X-Koordinate der Vorschau den ursprünglichen DMX-Wert und die Y-Koordinate den geänderten DMX-Wert.
-Beim Klicken auf einen Handler wird dies deutlicher, da die Felder oberhalb der Kurvenvorschau mit den genannten Werten gefüllt werden.
-Handler können einfach mit der Maus verschoben werden, indem man sie herumzieht oder indem man die Werte der ursprünglichen oder geänderten DMX-Werte manuell ändert.
+Auf der rechten Seite des Fensters wird eine Liste der verfügbaren Modifikatorvorlagen angezeigt.  
+Durch Klicken auf eine Vorlage in der Liste wird die Kurvenvorschau auf der linken Seite des Fensters angezeigt.  
+Eine Modifikatorkurve besteht aus einer Reihe von Linien, die darstellen, wie ein DMX-Kanal geändert werden soll, wenn sich sein Wert ändert.  
+Jede Zeile beginnt und endet mit einem sogenannten „Handler“. Ein Modifikator kann praktisch unendlich viele Handler haben, aber es muss immer einen Handler für den DMX-Wert 0 und einen Handler für den DMX-Wert 255 geben, um den gesamten DMX-Wertebereich abzudecken.  
+Grundsätzlich repräsentiert die X-Koordinate der Vorschau den ursprünglichen DMX-Wert und die Y-Koordinate den geänderten DMX-Wert.  
+Beim Klicken auf einen Handler wird dies deutlicher, da die Felder oberhalb der Kurvenvorschau mit den genannten Werten gefüllt werden.  
+Handler können einfach mit der Maus verschoben werden, indem man sie herumzieht oder indem man die Werte der ursprünglichen oder geänderten DMX-Werte manuell ändert.  
 
-Um eine neue Vorlage zu erstellen, wählen Sie einfach eine vorhandene Vorlage aus, geben Sie ihr einen neuen Namen und fügen Sie mit den Schaltflächen ![](/basics/edit_add.png) und ![](/basics/edit_remove.png) nach Bedarf Handler hinzu bzw. entfernen Sie sie.
+Um eine neue Vorlage zu erstellen, wählen Sie einfach eine vorhandene Vorlage aus, geben Sie ihr einen neuen Namen und fügen Sie mit den Schaltflächen ![](/basics/edit_add.png) und ![](/basics/edit_remove.png) nach Bedarf Handler hinzu bzw. entfernen Sie sie.  
 Wenn Sie fertig sind, klicken Sie einfach auf die Schaltfläche ![](/basics/filesave.png) und Ihre Vorlage wird in Ihrem Benutzervorlagenordner gespeichert. Bitte sehen Sie sich die Seite „Fragen und Antworten“ (/basics/questions-and-answers) an, um diesen Ordner zu finden.
 
 Kanalmodifikator-Vorlagen

--- a/pages/03.fixture-manager/06.fixture-remapping/default.v4_de.md
+++ b/pages/03.fixture-manager/06.fixture-remapping/default.v4_de.md
@@ -4,20 +4,20 @@ date: '11:36 21-08-2023'
 media_order: fixture_remap.png
 ---
 
-Ab Version 4.4.1 bietet QLC+ eine Funktion namens Fixtures Remapping.
-Wenn Sie Live-Shows an verschiedenen Veranstaltungsorten durchführen, können Sie möglicherweise erst in letzter Minute herausfinden, welche [Geräte](/basics/glossary-and-concepts#fixtures) dort installiert sind. Nun, die Neuzuordnung von Vorrichtungen hilft Ihnen, Ihre vorhandenen Projekte in dieser und vielen anderen Situationen zu nutzen, beispielsweise wenn Sie eine fehlerhafte Vorrichtung ersetzen müssen oder wenn Sie gemietete Ausrüstung zusätzlich zu Ihrer eigenen verwenden möchten.
-Sie können beispielsweise ein Projekt mit nur einem PAR, einem Moving Head und einem Scanner einrichten. Wenn Sie den Veranstaltungsort erreichen, an dem die Show stattfinden wird, können Sie Ihre Geräte den dort vorgefundenen Geräten zuordnen, zum Beispiel 50 PARs, 30 Moving Heads und 15 Scanner.
-Mit QLC+ dauert dieser Vorgang nur wenige Minuten!
+Ab Version 4.4.1 bietet QLC+ eine Funktion namens Fixtures Remapping.  
+Wenn Sie Live-Shows an verschiedenen Veranstaltungsorten durchführen, können Sie möglicherweise erst in letzter Minute herausfinden, welche [Geräte](/basics/glossary-and-concepts#fixtures) dort installiert sind. Nun, die Neuzuordnung von Vorrichtungen hilft Ihnen, Ihre vorhandenen Projekte in dieser und vielen anderen Situationen zu nutzen, beispielsweise wenn Sie eine fehlerhafte Vorrichtung ersetzen müssen oder wenn Sie gemietete Ausrüstung zusätzlich zu Ihrer eigenen verwenden möchten.  
+Sie können beispielsweise ein Projekt mit nur einem PAR, einem Moving Head und einem Scanner einrichten. Wenn Sie den Veranstaltungsort erreichen, an dem die Show stattfinden wird, können Sie Ihre Geräte den dort vorgefundenen Geräten zuordnen, zum Beispiel 50 PARs, 30 Moving Heads und 15 Scanner.  
+Mit QLC+ dauert dieser Vorgang nur wenige Minuten!  
 
-Mit der Neuzuordnung von Geräten können Sie 1-zu-1- oder 1-zu-viele-Neuzuweisungen ganzer Geräte oder einzelner Kanäle durchführen. QLC+ wird so weit wie möglich versuchen, die ursprünglich im Projekt verwendeten Kanäle neuen Kanälen derselben Kategorie neu zuzuordnen.
-Wenn Sie den Neuzuordnungsvorgang bestätigen, wird automatisch ein neues Projekt gespeichert, um Ihr ursprüngliches Projekt beizubehalten.
-Alle Geräte, Szenen, EFX, virtuellen Konsolen-Widgets und Audio-Trigger, die im Originalprojekt gefunden wurden, werden neu zugeordnet, sodass sie auf der neuen Geräteliste funktionieren.
+Mit der Neuzuordnung von Geräten können Sie 1-zu-1- oder 1-zu-viele-Neuzuweisungen ganzer Geräte oder einzelner Kanäle durchführen. QLC+ wird so weit wie möglich versuchen, die ursprünglich im Projekt verwendeten Kanäle neuen Kanälen derselben Kategorie neu zuzuordnen.  
+Wenn Sie den Neuzuordnungsvorgang bestätigen, wird automatisch ein neues Projekt gespeichert, um Ihr ursprüngliches Projekt beizubehalten.  
+Alle Geräte, Szenen, EFX, virtuellen Konsolen-Widgets und Audio-Trigger, die im Originalprojekt gefunden wurden, werden neu zugeordnet, sodass sie auf der neuen Geräteliste funktionieren.  
 
 
 Neuzuordnungsfenster
 ----------------
 
-Lassen Sie uns nun erklären, wie Sie das Fixture-Remapping-Fenster verwenden, beginnend mit einem Screenshot eines vollständigen Beispiels:
+Lassen Sie uns nun erklären, wie Sie das Fixture-Remapping-Fenster verwenden, beginnend mit einem Screenshot eines vollständigen Beispiels:  
 
 ![](fixture_remap.png)
 

--- a/pages/04.function-manager/01.scene-editor/default.v4_de.md
+++ b/pages/04.function-manager/01.scene-editor/default.v4_de.md
@@ -2,13 +2,13 @@
 title: 'Szeneneditor'
 ---
 
-Der Szeneneditor wird, wie der Name schon sagt zum Bearbeiten von ![](/basics/scene.png) [Szene](/basics/glossary-and-concepts#szene)-Funktionen verwendet. Der Editor ist in Registerkarten unterteilt; Mit der ersten Registerkarte **Allgemein** steuern Sie die Liste der Geräte und [Kanalgruppen](/basics/glossary-and-concepts#kanalgruppen), die an der Szenenbearbeitung teilnehmen, zusammen mit dem Szenennamen.
+Der Szeneneditor wird, wie der Name schon sagt zum Bearbeiten von ![](/basics/scene.png) [Szene](/basics/glossary-and-concepts#szene)-Funktionen verwendet. Der Editor ist in Registerkarten unterteilt; Mit der ersten Registerkarte **Allgemein** steuern Sie die Liste der Geräte und [Kanalgruppen](/basics/glossary-and-concepts#kanalgruppen), die an der Szenenbearbeitung teilnehmen, zusammen mit dem Szenennamen.  
 Alle nachfolgenden Registerkarten werden verwendet, um die einzelnen Kanalwerte für jedes Gerät und, falls welche definiert sind, die Werte der Kanalgruppen zu steuern.
 
 Allgemeine Tab-Steuerelemente
 --------------------
 
-Im linken Teil des Bildschirms werden die Schaltflächen zur Steuerung der in der Szene verwendeten Geräte angezeigt.
+Im linken Teil des Bildschirms werden die Schaltflächen zur Steuerung der in der Szene verwendeten Geräte angezeigt.  
 
 |     |     |
 | --- | --- |
@@ -31,13 +31,13 @@ Im rechten Teil des Bildschirms werden die Schaltflächen zur Steuerung der in d
 Registerkarten für Kanalgruppen
 -------------------
 
-Diese Registerkarte wird nur angezeigt, wenn in der Registerkarte „Allgemein“ eine oder mehrere Kanalgruppen ausgewählt sind.
+Diese Registerkarte wird nur angezeigt, wenn in der Registerkarte „Allgemein“ eine oder mehrere Kanalgruppen ausgewählt sind.  
 Jede Kanalgruppe wird mit einer Schnellzugriffstaste für Makros ([Click And Go](/basics/glossary-and-concepts#click-and-go) falls unterstützt), einer Beschriftung mit dem Gruppenwert, einem Fader und dem Namen der Gruppe angezeigt.
 
 Fixture-Registerkarten
 ------------
 
-Jedes Gerät wird durch eine eigene Registerkarte dargestellt, die Schieberegler für jeden Kanal des Geräts enthält. Jeder Kanal kann mit einem Kontrollkästchen oben in der Kanaleinheit aktiviert oder deaktiviert werden. Der Wert jedes Kanals kann entweder durch Eingabe des Werts in das Bearbeitungsfeld oben auf dem Schieberegler oder durch Bewegen des Schiebereglers festgelegt werden. Kanäle, die mehrere Funktionen wie Gobos, Farben usw. bereitstellen, verfügen außerdem über eine Schaltfläche über dem Kanalschieberegler. Mit dieser Schaltfläche können Sie direkt eine bestimmte Funktion oder Fähigkeit auswählen, die von diesem Kanal bereitgestellt wird.
+Jedes Gerät wird durch eine eigene Registerkarte dargestellt, die Schieberegler für jeden Kanal des Geräts enthält. Jeder Kanal kann mit einem Kontrollkästchen oben in der Kanaleinheit aktiviert oder deaktiviert werden. Der Wert jedes Kanals kann entweder durch Eingabe des Werts in das Bearbeitungsfeld oben auf dem Schieberegler oder durch Bewegen des Schiebereglers festgelegt werden. Kanäle, die mehrere Funktionen wie Gobos, Farben usw. bereitstellen, verfügen außerdem über eine Schaltfläche über dem Kanalschieberegler. Mit dieser Schaltfläche können Sie direkt eine bestimmte Funktion oder Fähigkeit auswählen, die von diesem Kanal bereitgestellt wird.  
 **Hinweis**: Die Tastenkombination zum Wechseln zwischen den Bearbeitungsfeldern für Kanalwerte lautet „**Tabulatortaste**“, um nach rechts zu wechseln, und „**Umschalttaste + Tabulatortaste**“, um nach links zu wechseln.
 
 ### Status des Kanals aktiviert/deaktiviert

--- a/pages/04.function-manager/02.chaser-editor/default.v4_de.md
+++ b/pages/04.function-manager/02.chaser-editor/default.v4_de.md
@@ -3,7 +3,7 @@ title: Chaser-Editor
 date: '12:08 21-08-2023'
 ---
 
-Der Chaser-Editor wird, wie der Name schon sagt, zum Bearbeiten von ![](/basics/chaser.png) [Chaser](/basics/glossary-and-concepts#chaser)-Funktionen verwendet.
+Der Chaser-Editor wird, wie der Name schon sagt, zum Bearbeiten von ![](/basics/chaser.png) [Chaser](/basics/glossary-and-concepts#chaser)-Funktionen verwendet.  
 Ein Chaser besteht aus Schritten und jeder Schritt wird durch dargestellt
 
 * Eine progressive Zahl

--- a/pages/04.function-manager/03.show-editor/default.v4_de.md
+++ b/pages/04.function-manager/03.show-editor/default.v4_de.md
@@ -3,8 +3,8 @@ title: 'Show-Editor'
 date: '12:10 21-08-2023'
 ---
 
-Der Show-Editor ist ein Bedienfeld zum Anzeigen der aktuellen Struktur einer ![](/basics/show.png) [Show](/basics/glossary-and-concepts#show), die mit dem [Show-Manager](/show-manager).
-Im Moment kann der Show-Editor eine Show nur umbenennen, was im Show-Manager nicht möglich ist.
+Der Show-Editor ist ein Bedienfeld zum Anzeigen der aktuellen Struktur einer ![](/basics/show.png) [Show](/basics/glossary-and-concepts#show), die mit dem [Show-Manager](/show-manager).  
+Im Moment kann der Show-Editor eine Show nur umbenennen, was im Show-Manager nicht möglich ist.  
 
 Die Baumansicht dieses Panels zeigt nützliche Informationen zur angezeigten Show an, wie zum Beispiel:
 

--- a/pages/04.function-manager/05.collection-editor/default.v4_de.md
+++ b/pages/04.function-manager/05.collection-editor/default.v4_de.md
@@ -3,13 +3,13 @@ title: 'Sammlungseditor'
 date: '12:21 21-08-2023'
 ---
 
-Der Sammlungseditor wird, wie der Name schon sagt, zum Bearbeiten von ![](/basics/collection.png) [Sammlung](/basics/glossary-and-concepts#sammlung)-Funktionen verwendet.
-Sammlungen sind in einem Workflow, in dem Sie QLC+-Funktionen für bestimmte Bereiche Ihrer Show erstellen, sehr hilfreich. Sie können beispielsweise eine Reihe von Szenen erstellen, um nur Farben zu steuern, einige andere Szenen, um nur Positionen zu steuern und so weiter. Anschließend können Sie eine Reihe von Chasern und EFX für Automatisierungen erstellen.
+Der Sammlungseditor wird, wie der Name schon sagt, zum Bearbeiten von ![](/basics/collection.png) [Sammlung](/basics/glossary-and-concepts#sammlung)-Funktionen verwendet.  
+Sammlungen sind in einem Workflow, in dem Sie QLC+-Funktionen für bestimmte Bereiche Ihrer Show erstellen, sehr hilfreich. Sie können beispielsweise eine Reihe von Szenen erstellen, um nur Farben zu steuern, einige andere Szenen, um nur Positionen zu steuern und so weiter. Anschließend können Sie eine Reihe von Chasern und EFX für Automatisierungen erstellen.  
 Wenn Sie alle Grundelemente Ihrer Show erstellt haben, können Sie mithilfe von Sammlungen eine Art „Abkürzung“ für zusammengesetzte Szenen erstellen. Zum Beispiel eine Farbszene + eine Positionsszene.
 
 **Hinweis:** Sammlungen haben keine Geschwindigkeitseinstellung; Jede Funktion, die Sie in eine Sammlung aufnehmen, folgt ihren eigenen Geschwindigkeitseinstellungen.
 
-**Wichtig**: Die Reihenfolge der Funktionen in einer Sammlung ist von grundlegender Bedeutung, wenn es um die HTP/LTP-Nutzung oder relative Werte geht. QLC+ startet intern die Funktionen einer Sammlung vom ersten bis zum letzten. Wenn sie also dieselben Kanäle verwenden, sollten Sie dies im Hinterkopf behalten, da es sonst zu unerwünschten Effekten kommen kann.
+**Wichtig**: Die Reihenfolge der Funktionen in einer Sammlung ist von grundlegender Bedeutung, wenn es um die HTP/LTP-Nutzung oder relative Werte geht. QLC+ startet intern die Funktionen einer Sammlung vom ersten bis zum letzten. Wenn sie also dieselben Kanäle verwenden, sollten Sie dies im Hinterkopf behalten, da es sonst zu unerwünschten Effekten kommen kann.  
 Beispielsweise muss eine Szene, die Pan/Tilt-Kanäle + einen EFX im relativen Modus einstellt, eine genaue Reihenfolge haben: die Szene an der ersten Position und der EFX an der zweiten Position.
 
 ### Steuerelemente

--- a/pages/04.function-manager/07.rgb-script-api/default.v4.md
+++ b/pages/04.function-manager/07.rgb-script-api/default.v4.md
@@ -40,7 +40,7 @@ The scripts must be self-executing, i.e. when they are evaluated, the script its
 However, a script with nothing more than an empty object does nothing, no matter how self-executing it might be. You must also declare some **properties** for the returned object so that QLC+ knows how to use the script and to show it to the user (you). So, you need to declare the following properties for the returned script object:
 
 * **apiVersion:** The API version that the script follows. Currently, the accepted values are '1' or '2'.  
-    apiVersion 1 allows simple scripting and easier coding, while apiVersion 2 offers advanced features [described below](#api-version-2).
+    apiVersion 1 allows simple scripting and easier coding, while apiVersion 2 offers advanced features [described below](#api-version-2).  
     Any other value will cause the script to be treated as invalid.
 * **name:** The name of your script. This name appears in the pattern selection box in the [RGB Matrix Editor](../rgb-matrix-editor)
 * **author:** The name of the person who has written the script. **You.**

--- a/pages/04.function-manager/07.rgb-script-api/default.v4_de.md
+++ b/pages/04.function-manager/07.rgb-script-api/default.v4_de.md
@@ -39,15 +39,15 @@ Die Skripte müssen selbstausführend sein, d.h. wenn sie ausgewertet werden, wi
 
 Allerdings bewirkt ein Skript, das nichts weiter als ein leeres Objekt enthält, nichts, egal wie selbstausführend es auch sein mag. Sie müssen auch einige **Eigenschaften** für das zurückgegebene Objekt deklarieren, damit QLC+ weiß, wie das Skript verwendet wird und es dem Benutzer (Ihnen) angezeigt wird. Daher müssen Sie die folgenden Eigenschaften für das zurückgegebene Skriptobjekt deklarieren:
 
-* **apiVersion:** Die API-Version, der das Skript folgt. Derzeit sind die akzeptierten Werte „1“ oder „2“.
-    apiVersion 1 ermöglicht einfaches Scripting und einfacheres Codieren, während apiVersion 2 erweiterte Funktionen [unten beschrieben](#api-version-2) bietet.
+* **apiVersion:** Die API-Version, der das Skript folgt. Derzeit sind die akzeptierten Werte „1“ oder „2“.  
+    apiVersion 1 ermöglicht einfaches Scripting und einfacheres Codieren, während apiVersion 2 erweiterte Funktionen [unten beschrieben](#api-version-2) bietet.  
     Jeder andere Wert führt dazu, dass das Skript als ungültig behandelt wird.
 * **Name:** Der Name Ihres Skripts. Dieser Name erscheint im Musterauswahlfeld im [RGB-Matrix-Editor](../rgb-matrix-editor)
 * **Autor:** Der Name der Person, die das Drehbuch geschrieben hat. **Du.**
-* **acceptColors (optional):** Informiert QLC+, ob das Skript eine Startfarbe, eine Endfarbe oder keine akzeptieren kann.
-    „acceptColors = 0“ bedeutet, dass keine Farben akzeptiert/benötigt werden. Das bedeutet, dass das Skript selbstständig die Farbinformationen für die Matrixpixel generiert.
-    „acceptColors = 1“ bedeutet, dass das Skript nur die Startfarbe benötigt.
-    „acceptColors = 2“ bedeutet, dass sowohl Start- als auch Endfarben vom Skript akzeptiert werden.
+* **acceptColors (optional):** Informiert QLC+, ob das Skript eine Startfarbe, eine Endfarbe oder keine akzeptieren kann.  
+    „acceptColors = 0“ bedeutet, dass keine Farben akzeptiert/benötigt werden. Das bedeutet, dass das Skript selbstständig die Farbinformationen für die Matrixpixel generiert.  
+    „acceptColors = 1“ bedeutet, dass das Skript nur die Startfarbe benötigt.  
+    „acceptColors = 2“ bedeutet, dass sowohl Start- als auch Endfarben vom Skript akzeptiert werden.  
     Wenn „acceptColors“ nicht angegeben ist, verwendet QLC+ standardmäßig den Wert „2“.
 
 Vor diesem Hintergrund fügen wir dem Skript Deklarationen für diese drei Eigenschaften hinzu:
@@ -141,11 +141,11 @@ Genau wie die vorherige Funktion fügen wir auch diese andere zum Skript hinzu. 
 
 ### API version 2
 
-RGB Script API Version 2 führt das Konzept der **Eigenschaften** ein. Mit Eigenschaften kann ein Skript durch den Austausch von Parametern mit der QLC+-Engine interagieren und so die Möglichkeiten eines RGB-Skripts erweitern.
-Beispiele für solche Eigenschaften können die Animationsausrichtung, die Anzahl der zu rendernden Objekte usw. sein.
+RGB Script API Version 2 führt das Konzept der **Eigenschaften** ein. Mit Eigenschaften kann ein Skript durch den Austausch von Parametern mit der QLC+-Engine interagieren und so die Möglichkeiten eines RGB-Skripts erweitern.  
+Beispiele für solche Eigenschaften können die Animationsausrichtung, die Anzahl der zu rendernden Objekte usw. sein.  
 
-Das Hinzufügen von Eigenschaften zu Ihrem Skript ist recht einfach, erfordert jedoch eine bestimmte Syntax, die in diesem Absatz erläutert wird.
-Machen wir ein Beispiel:v
+Das Hinzufügen von Eigenschaften zu Ihrem Skript ist recht einfach, erfordert jedoch eine bestimmte Syntax, die in diesem Absatz erläutert wird.  
+Machen wir ein Beispiel:
 
 ```javascript
 algo.orientation = 0;
@@ -158,9 +158,9 @@ Die drei Zeilen oben geben Folgendes an:
 1. Das Skript verfügt über eine interne Eigenschaft, die durch die Variable „orientation“ dargestellt wird.
 2. Erstellen Sie das Eigenschaftenarray. Dies wird nur einmal benötigt
 3. Fügen Sie die Eigenschaftsbeschreibung in das Eigenschaftenarray ein (fügen Sie sie hinzu). Dies ist, was die QLC+-Engine tatsächlich liest, um Daten mit dem Skript auszutauschen
-Die dritte Zeile ist in der Tat die interessanteste und die Syntax der im Eigenschaften-Array gespeicherten Zeichenfolge muss befolgt werden, um Fehler beim Laden des Skripts zu vermeiden.
-Attribute müssen das Format „**Name:Wert**“ haben und jedes Attribut muss durch ein Pipe-Zeichen „**|**“ von den anderen getrennt sein.
-Nachfolgend eine Tabelle der akzeptierten Attribute und der Bedeutung ihrer Werte.
+Die dritte Zeile ist in der Tat die interessanteste und die Syntax der im Eigenschaften-Array gespeicherten Zeichenfolge muss befolgt werden, um Fehler beim Laden des Skripts zu vermeiden.  
+Attribute müssen das Format „**Name:Wert**“ haben und jedes Attribut muss durch ein Pipe-Zeichen „**|**“ von den anderen getrennt sein.  
+Nachfolgend eine Tabelle der akzeptierten Attribute und der Bedeutung ihrer Werte.  
 
 |     |     |
 | --- | --- |

--- a/pages/04.function-manager/08.script-editor/default.v4_de.md
+++ b/pages/04.function-manager/08.script-editor/default.v4_de.md
@@ -3,9 +3,9 @@ title: 'Skript-Editor'
 date: '04:07 22-08-2023'
 ---
 
-Der Skripteditor wird, wie der Name schon sagt, zum Bearbeiten von ![](/basics/script.png) [Skript](/basics/glossary-and-concepts#skript)-Funktionen verwendet.
-Es besteht im Wesentlichen aus einem Texteditor, in dem der Benutzer ein Skript unter Verwendung einer Metasprache mit einer unten beschriebenen Syntax schreiben kann.
-Das Skript kann manuell geändert werden, wenn Sie die Syntax der Sprache vollständig verstehen. Andernfalls stehen ganz rechts im Editor einige Hilfsschaltflächen zur Verfügung, um die Erstellung/Bearbeitung des Skripts zu beschleunigen und zu erleichtern.
+Der Skripteditor wird, wie der Name schon sagt, zum Bearbeiten von ![](/basics/script.png) [Skript](/basics/glossary-and-concepts#skript)-Funktionen verwendet.  
+Es besteht im Wesentlichen aus einem Texteditor, in dem der Benutzer ein Skript unter Verwendung einer Metasprache mit einer unten beschriebenen Syntax schreiben kann.  
+Das Skript kann manuell geändert werden, wenn Sie die Syntax der Sprache vollständig verstehen. Andernfalls stehen ganz rechts im Editor einige Hilfsschaltflächen zur Verfügung, um die Erstellung/Bearbeitung des Skripts zu beschleunigen und zu erleichtern.  
 Jede Zeile eines Skripts wird von QLC+ in sequentieller Reihenfolge ausgeführt.
 
 ### Kontrollen
@@ -23,8 +23,8 @@ Jede Zeile eines Skripts wird von QLC+ in sequentieller Reihenfolge ausgeführt.
 
 ### Sprachsyntax
 
-Die QLC+ Script-Metasprache basiert auf einem **Schlüsselwort:Wert**-Modell mit einigen Einfügungen von C-Sprachsyntaxregeln.
-Jede Codezeile wird von der QLC+-Engine analysiert und überprüft, um das Vorhandensein von Syntaxfehlern zu erkennen.
+Die QLC+ Script-Metasprache basiert auf einem **Schlüsselwort:Wert**-Modell mit einigen Einfügungen von C-Sprachsyntaxregeln.  
+Jede Codezeile wird von der QLC+-Engine analysiert und überprüft, um das Vorhandensein von Syntaxfehlern zu erkennen.  
 Hier ist eine Tabelle, die jedes von der Skript-Engine akzeptierte Schlüsselwort und seine Syntax beschreibt.v
 
 #### Startfunktion

--- a/pages/04.function-manager/09.audio-editor/default.v4_de.md
+++ b/pages/04.function-manager/09.audio-editor/default.v4_de.md
@@ -3,7 +3,7 @@ title: 'Audio-Editor'
 date: '04:32 22-08-2023'
 ---
 
-Der Audio-Editor wird, wie der Name schon sagt, zum Bearbeiten von ![](/basics/audio.png) [Audio](/basics/glossary-and-concepts#audio)-Funktionen verwendet.
+Der Audio-Editor wird, wie der Name schon sagt, zum Bearbeiten von ![](/basics/audio.png) [Audio](/basics/glossary-and-concepts#audio)-Funktionen verwendet.  
 Es bietet grundlegende Steuerelemente und zeigt Informationen über die angehängte Audiodatei an.
 
 Controls

--- a/pages/04.function-manager/10.video-editor/default.v4_de.md
+++ b/pages/04.function-manager/10.video-editor/default.v4_de.md
@@ -3,7 +3,7 @@ title: 'Video-Editor'
 date: '04:33 22-08-2023'
 ---
 
-Der Video-Editor wird, wie der Name schon sagt, zum Bearbeiten von ![](/basics/video.png) [Video](/basics/glossary-and-concepts#video)-Funktionen verwendet.
+Der Video-Editor wird, wie der Name schon sagt, zum Bearbeiten von ![](/basics/video.png) [Video](/basics/glossary-and-concepts#video)-Funktionen verwendet.  
 
 Steuerungen
 --------

--- a/pages/05.show-manager/chapter.v4.md
+++ b/pages/05.show-manager/chapter.v4.md
@@ -86,7 +86,7 @@ A popup will appear asking the name to assign to the Show. It is possible to cha
 When you add a track, a popup will ask you to select an existing function or to create a new one with a default name.  
 When done, a new track will be created. All the sequences created on this track will act only on the associated Scene, not affecting any of the other tracks.  
 A newly created track will be set automatically as active. An active track has a green light on the left hand side.  
-A Track can be set to ![](track-mute.png) mute and ![](track-solo.png) solo states. The mute state will exclude the track from the playback, while the solo state will mute all the other tracks of the Show.
+A Track can be set to ![](track-mute.png) mute and ![](track-solo.png) solo states. The mute state will exclude the track from the playback, while the solo state will mute all the other tracks of the Show.  
 When right clicking on a track, it is possible to move it up ![](/basics/up.png) or down ![](/basics/down.png) for logical ordering.  
 Once selected, a track will display its [Scene Editor](/function-manager/scene-editor) on the bottom of the screen.
 

--- a/pages/05.show-manager/chapter.v4_ca.md
+++ b/pages/05.show-manager/chapter.v4_ca.md
@@ -88,7 +88,7 @@ Apareixerà una finestra emergent que demanarà un nom per a assignar-lo al Show
 Quan afegiu una pista, una finestra emergent us demanarà que seleccioneu una funció existent o que en creeu una de nova amb un nom predeterminat.  
 En acabar, es crearà una pista nova. Totes les seqüències creades en aquesta pista actuaran només en l'escena associada, no afectant cap de les altres pistes.  
 Una pista de nova creació s'establirà automàticament com a activa. Una pista activa té una llum verda al costat esquerre.  
-Es pot establir una pista en els estats de ![](track-mute.png) silenci i ![](track-solo.png) solo. L'estat silenci exclourà la pista de la reproducció, mentre que l'estat solo silenciarà totes les altres pistes del Show.
+Es pot establir una pista en els estats de ![](track-mute.png) silenci i ![](track-solo.png) solo. L'estat silenci exclourà la pista de la reproducció, mentre que l'estat solo silenciarà totes les altres pistes del Show.  
 En fer clic dret sobre una pista, és possible moure-la cap amunt ![](/basics/up.png) o cap avall ![](/basics/down.png) per a l'ordenació lògica.  
 Un cop seleccionada, una pista mostrarà el seu [Editor d'Escenes](/function-manager/scene-editor) a la part inferior de la pantalla.
 

--- a/pages/05.show-manager/chapter.v4_de.md
+++ b/pages/05.show-manager/chapter.v4_de.md
@@ -86,7 +86,7 @@ Es erscheint ein Popup, in dem Sie nach dem Namen gefragt werden, den Sie der Sh
 Wenn Sie einen Track hinzufügen, werden Sie in einem Popup aufgefordert, eine vorhandene Funktion auszuwählen oder eine neue mit einem Standardnamen zu erstellen.
 Wenn Sie fertig sind, wird ein neuer Track erstellt. Alle auf dieser Spur erstellten Sequenzen wirken sich nur auf die zugehörige Szene aus und haben keinen Einfluss auf die anderen Spuren.
 Ein neu erstellter Track wird automatisch als aktiv gesetzt. Eine aktive Spur hat auf der linken Seite ein grünes Licht.
-Eine Spur kann auf ![](track-mute.png) Stummschaltung und ![](track-solo.png) Solo-Zustand eingestellt werden. Im Stummschaltungszustand wird die Spur von der Wiedergabe ausgeschlossen, während im Solo-Zustand alle anderen Spuren der Show stummgeschaltet werden.
+Eine Spur kann auf ![](track-mute.png) Stummschaltung und ![](track-solo.png) Solo-Zustand eingestellt werden. Im Stummschaltungszustand wird die Spur von der Wiedergabe ausgeschlossen, während im Solo-Zustand alle anderen Spuren der Show stummgeschaltet werden.  
 Wenn Sie mit der rechten Maustaste auf einen Titel klicken, können Sie ihn nach oben ![](/basics/up.png) oder nach unten ![](/basics/down.png) verschieben, um eine logische Reihenfolge zu erreichen.
 Sobald eine Spur ausgewählt ist, wird ihr [Szeneneditor](/function-manager/scene-editor) unten auf dem Bildschirm angezeigt.
 

--- a/pages/05.show-manager/chapter.v4_de.md
+++ b/pages/05.show-manager/chapter.v4_de.md
@@ -14,38 +14,38 @@ taxonomy:
 
 # Showmanager
 
-Diese Funktion soll Benutzern die Möglichkeit geben, eine zeitgesteuerte Show auf benutzerfreundliche und vollständig grafische Weise einzurichten.
-Die grafische Benutzeroberfläche zeigt eine Mehrspuransicht, wie sie für Audiosequenzer oder Videobearbeitungssoftware typisch ist, und mit ihr können Benutzer QLC+-[Funktionen](/basics/glossary-and-concepts#funktionen) an der gewünschten Stelle und zum gewünschten Zeitpunkt in der Ansicht platzieren .
-Show Manager bietet dank seines visuell orientierten Ansatzes viel Flexibilität bei der Erstellung einer [Show](/basics/glossary-and-concepts#show). Sobald Sie die Grundelemente verstanden haben, ist es sehr einfach, die vorhandenen Funktionen zu erstellen, zu verschieben oder zu bearbeiten und eine Show durch das Hinzufügen neuer Tracks zu verbessern.
+Diese Funktion soll Benutzern die Möglichkeit geben, eine zeitgesteuerte Show auf benutzerfreundliche und vollständig grafische Weise einzurichten.  
+Die grafische Benutzeroberfläche zeigt eine Mehrspuransicht, wie sie für Audiosequenzer oder Videobearbeitungssoftware typisch ist, und mit ihr können Benutzer QLC+-[Funktionen](/basics/glossary-and-concepts#funktionen) an der gewünschten Stelle und zum gewünschten Zeitpunkt in der Ansicht platzieren.  
+Show Manager bietet dank seines visuell orientierten Ansatzes viel Flexibilität bei der Erstellung einer [Show](/basics/glossary-and-concepts#show). Sobald Sie die Grundelemente verstanden haben, ist es sehr einfach, die vorhandenen Funktionen zu erstellen, zu verschieben oder zu bearbeiten und eine Show durch das Hinzufügen neuer Tracks zu verbessern.  
 
-Typische Anwendungsfälle für Shows sind Auftritte, bei denen eine Band Lieder nach einem Metronom spielt und die Lichtshow immer die gleiche sein muss, die der Musik folgt.
-Ein weiterer Fall sind visuelle Unterhaltungsshows, bei denen Tänzer oder Sänger der Musik folgen und Lichter zum richtigen Zeitpunkt für Atmosphäre sorgen.
+Typische Anwendungsfälle für Shows sind Auftritte, bei denen eine Band Lieder nach einem Metronom spielt und die Lichtshow immer die gleiche sein muss, die der Musik folgt.  
+Ein weiterer Fall sind visuelle Unterhaltungsshows, bei denen Tänzer oder Sänger der Musik folgen und Lichter zum richtigen Zeitpunkt für Atmosphäre sorgen.  
 
-Der Show Manager regt Benutzer dazu an, die Sequenzfunktion intensiv zu nutzen. Hier ist die Erklärung des Unterschieds zwischen einem Chaser und einer Sequenz.
+Der Show Manager regt Benutzer dazu an, die Sequenzfunktion intensiv zu nutzen. Hier ist die Erklärung des Unterschieds zwischen einem Chaser und einer Sequenz.  
 
 Sequenzen vs. Chaser
 --------------------
 
-Auch wenn die Funktionen [Sequenz](/basics/glossary-and-concepts#sequenz) und [Chaser](/basics/glossary-and-concepts#chaser) einige Gemeinsamkeiten haben, sind sie nicht dasselbe.
-Falls noch nicht geschehen, können Sie die Definitionen noch einmal auf der Seite [Grundlegende Konzepte und Glossar](/basics/glossary-and-concepts) dieser Dokumentation lesen.
+Auch wenn die Funktionen [Sequenz](/basics/glossary-and-concepts#sequenz) und [Chaser](/basics/glossary-and-concepts#chaser) einige Gemeinsamkeiten haben, sind sie nicht dasselbe.  
+Falls noch nicht geschehen, können Sie die Definitionen noch einmal auf der Seite [Grundlegende Konzepte und Glossar](/basics/glossary-and-concepts) dieser Dokumentation lesen.  
 Die Hauptunterschiede sind:
 
-**Schritte**: Die Schritte eines Chasers können jede QLC+-Funktion darstellen, während die Schritte einer Sequenz verschiedene Werte derselben [Szene](/basics/glossary-and-concepts#szene) darstellen.
+**Schritte**: Die Schritte eines Chasers können jede QLC+-Funktion darstellen, während die Schritte einer Sequenz verschiedene Werte derselben [Szene](/basics/glossary-and-concepts#szene) darstellen.  
     Mit anderen Worten: Ein Chaser ist eine unabhängige Funktion, während eine Sequenz nur über einer Szene existieren kann.
     Der Grund dafür ist, wie bereits erwähnt, der visuelle Ansatz des Showmanagers. Wenn eine Spur einer Show die grafische Darstellung einer Szene ist, ist es intuitiver anzunehmen, dass jede auf dieser Spur erstellte Sequenz eine Funktion ist, die die Werte dieser Szene steuert.
 
-**Reihenfolge**: Chaser können in beliebiger Reihenfolge wiedergegeben werden (Vorwärts, Rückwärts, Ping-Pong, Zufall), während im Show Manager Sequenzen immer vom Anfang bis zum Ende (Vorwärts) wiedergegeben werden. Dies hängt wiederum mit dem visuellen Aspekt des Show Managers zusammen, bei dem die Wiedergabe eine natürliche Zeitvorwärtsrichtung hat.
+**Reihenfolge**: Chaser können in beliebiger Reihenfolge wiedergegeben werden (Vorwärts, Rückwärts, Ping-Pong, Zufall), während im Show Manager Sequenzen immer vom Anfang bis zum Ende (Vorwärts) wiedergegeben werden. Dies hängt wiederum mit dem visuellen Aspekt des Show Managers zusammen, bei dem die Wiedergabe eine natürliche Zeitvorwärtsrichtung hat.  
     Andererseits können mit dem Funktionsmanager erstellte Sequenzen die gleichen Reihenfolgeeigenschaften wie Chaser haben.
 
-**Bearbeiten**: Auch der Bearbeitungsansatz zwischen Sequenzen und Chaser ist unterschiedlich.
-    Normalerweise sieht der Arbeitsablauf eines Chasers so aus: Erstellen Sie eine Funktion und fügen Sie sie dann als Schritt zum Chaser hinzu.
-    Der Arbeitsablauf einer Sequenz ist: Erstellen Sie eine Szene, erstellen Sie eine Sequenz darüber und fügen Sie Schritte hinzu.
-    Der Sequenz-Ansatz kann bei der Gestaltung einer Lichtshow sehr effektiv sein, wenn Sie wissen, welche Leuchten Sie verwenden werden. Ein weiterer großer Vorteil der Sequenzbearbeitung besteht darin, dass beim Erstellen eines neuen Schritts die Werte des vorherigen Schritts in den neuen kopiert werden. Der Benutzer muss also lediglich die Unterschiede zwischen ihnen anpassen.
-    Wenn Sie 500 Schritte erstellen und diese alle unterschiedlich sind, dauert die Erstellung von Sequenzen und Chasern fast gleich lange.
+**Bearbeiten**: Auch der Bearbeitungsansatz zwischen Sequenzen und Chaser ist unterschiedlich.  
+    Normalerweise sieht der Arbeitsablauf eines Chasers so aus: Erstellen Sie eine Funktion und fügen Sie sie dann als Schritt zum Chaser hinzu.  
+    Der Arbeitsablauf einer Sequenz ist: Erstellen Sie eine Szene, erstellen Sie eine Sequenz darüber und fügen Sie Schritte hinzu.  
+    Der Sequenz-Ansatz kann bei der Gestaltung einer Lichtshow sehr effektiv sein, wenn Sie wissen, welche Leuchten Sie verwenden werden. Ein weiterer großer Vorteil der Sequenzbearbeitung besteht darin, dass beim Erstellen eines neuen Schritts die Werte des vorherigen Schritts in den neuen kopiert werden. Der Benutzer muss also lediglich die Unterschiede zwischen ihnen anpassen.  
+    Wenn Sie 500 Schritte erstellen und diese alle unterschiedlich sind, dauert die Erstellung von Sequenzen und Chasern fast gleich lange.  
 
-**Synchronisierung**: Ein weiterer großer Vorteil der Verwendung von Sequenzen in einer Show besteht darin, dass eine Show leicht erweitert (oder reduziert) werden kann, während es Ihnen bei einem Chaser schwerfällt, die neuen Funktionen mit den vorhandenen zu synchronisieren.
-    Ein Beispiel. Nehmen wir an, Ihr Projekt steuert 50 Geräte, die eine Mischung aus Moving Heads, PARs und Scannern sind. Irgendwann kauft man ein paar Laser und möchte, dass sie zu bestimmten Zeitpunkten in vorhandenen Szenen aktiv werden. Mit dem Show Manager können Sie das in wenigen Minuten erledigen! Sie müssen lediglich die beiden neuen Geräte zum Projekt hinzufügen, eine Spur zu den von der Änderung betroffenen Shows hinzufügen und einige Sequenzen zur Steuerung der Laser erstellen.
-    Mit der Lebenslauffunktion des Show Managers sparen Sie außerdem viel Zeit beim Testen der neuen Änderungen.
+**Synchronisierung**: Ein weiterer großer Vorteil der Verwendung von Sequenzen in einer Show besteht darin, dass eine Show leicht erweitert (oder reduziert) werden kann, während es Ihnen bei einem Chaser schwerfällt, die neuen Funktionen mit den vorhandenen zu synchronisieren.  
+    Ein Beispiel. Nehmen wir an, Ihr Projekt steuert 50 Geräte, die eine Mischung aus Moving Heads, PARs und Scannern sind. Irgendwann kauft man ein paar Laser und möchte, dass sie zu bestimmten Zeitpunkten in vorhandenen Szenen aktiv werden. Mit dem Show Manager können Sie das in wenigen Minuten erledigen! Sie müssen lediglich die beiden neuen Geräte zum Projekt hinzufügen, eine Spur zu den von der Änderung betroffenen Shows hinzufügen und einige Sequenzen zur Steuerung der Laser erstellen.  
+    Mit der Lebenslauffunktion des Show Managers sparen Sie außerdem viel Zeit beim Testen der neuen Änderungen.  
     Bei Chasern müssten Sie sich wahrscheinlich mit komplexen [Sammlungen](/basics/glossary-and-concepts#sammlung) befassen und die Zeitabläufe einiger Schritte überprüfen, bevor Sie die richtige Kombination finden.
 
 Manager-Symbolleisten-Steuerelemente anzeigen
@@ -78,46 +78,46 @@ Der Show Manager ist so eingerichtet, dass er schnell und einfach verwendet werd
 
 #### 1. Eine neue Show hinzufügen ![](/basics/show.png)
 
-Zunächst müssen Sie der Ansicht eine neue Show hinzufügen. Dadurch wird eine leere Multitrack-Ansicht ohne Tracks und ohne Elemente erstellt, die zum Füllen bereit ist.
+Zunächst müssen Sie der Ansicht eine neue Show hinzufügen. Dadurch wird eine leere Multitrack-Ansicht ohne Tracks und ohne Elemente erstellt, die zum Füllen bereit ist.  
 Es erscheint ein Popup, in dem Sie nach dem Namen gefragt werden, den Sie der Show zuweisen möchten. Es ist möglich, den Namen nachträglich mit dem [Funktionsmanager](/function-manager) über das Bedienfeld [Show Editor](/function-manager/show-editor) zu ändern.
 
 #### 2. Einen Titel hinzufügen ![](/basics/edit_add.png)
 
-Wenn Sie einen Track hinzufügen, werden Sie in einem Popup aufgefordert, eine vorhandene Funktion auszuwählen oder eine neue mit einem Standardnamen zu erstellen.
-Wenn Sie fertig sind, wird ein neuer Track erstellt. Alle auf dieser Spur erstellten Sequenzen wirken sich nur auf die zugehörige Szene aus und haben keinen Einfluss auf die anderen Spuren.
-Ein neu erstellter Track wird automatisch als aktiv gesetzt. Eine aktive Spur hat auf der linken Seite ein grünes Licht.
+Wenn Sie einen Track hinzufügen, werden Sie in einem Popup aufgefordert, eine vorhandene Funktion auszuwählen oder eine neue mit einem Standardnamen zu erstellen.  
+Wenn Sie fertig sind, wird ein neuer Track erstellt. Alle auf dieser Spur erstellten Sequenzen wirken sich nur auf die zugehörige Szene aus und haben keinen Einfluss auf die anderen Spuren.  
+Ein neu erstellter Track wird automatisch als aktiv gesetzt. Eine aktive Spur hat auf der linken Seite ein grünes Licht.  
 Eine Spur kann auf ![](track-mute.png) Stummschaltung und ![](track-solo.png) Solo-Zustand eingestellt werden. Im Stummschaltungszustand wird die Spur von der Wiedergabe ausgeschlossen, während im Solo-Zustand alle anderen Spuren der Show stummgeschaltet werden.  
-Wenn Sie mit der rechten Maustaste auf einen Titel klicken, können Sie ihn nach oben ![](/basics/up.png) oder nach unten ![](/basics/down.png) verschieben, um eine logische Reihenfolge zu erreichen.
+Wenn Sie mit der rechten Maustaste auf einen Titel klicken, können Sie ihn nach oben ![](/basics/up.png) oder nach unten ![](/basics/down.png) verschieben, um eine logische Reihenfolge zu erreichen.  
 Sobald eine Spur ausgewählt ist, wird ihr [Szeneneditor](/function-manager/scene-editor) unten auf dem Bildschirm angezeigt.
 
 #### 3. Fügen Sie einige [Funktionen](/basics/glossary-and-concepts#funktionen) hinzu
 
-Wenn ein Titel aktiviert wurde, können Sie schnell eine ![](/basics/sequence.png) [Sequenz](/basics/glossary-and-concepts#sequenz) oder eine ![](/basics/audio.png) hinzufügen ) [Audio](/basics/glossary-and-concepts#audio) aufrufen, indem Sie auf die Symbolleistenschaltflächen klicken.
-Andernfalls ist es durch Klicken auf die Schaltfläche ![](/basics/edit_add.png) möglich, vorhandene QLC+-Funktionen zu importieren und zur Show-Timeline hinzuzufügen.
-Ein neues Element wird an der Cursorposition platziert, es ist jedoch jederzeit möglich, es an die gewünschte Zeit zu verschieben, indem Sie es einfach entlang der Zeitleiste ziehen.
-Ein Element kann nicht in eine andere Spur verschoben werden, da es an die Spur gebunden ist, in der es ursprünglich erstellt wurde.
-Mit den Symbolleistensymbolen kann ein Element kopiert ![](/basics/editcopy.png), eingefügt ![](/basics/editpaste.png) oder gelöscht ![](/basics/editdelete.png) werden. Das eingefügte Element wird an der aktuellen Cursorposition platziert.
-Die Hintergrundfarbe des Elements kann mit dem Symbolleistensymbol ![](/basics/color.png) geändert werden. Die zugewiesene Farbe wird in Ihrer Projektdatei gespeichert.
+Wenn ein Titel aktiviert wurde, können Sie schnell eine ![](/basics/sequence.png) [Sequenz](/basics/glossary-and-concepts#sequenz) oder eine ![](/basics/audio.png) [Audio](/basics/glossary-and-concepts#audio)-Funktion hinzufügen, indem Sie auf die Symbolleistenschaltflächen klicken.  
+Andernfalls ist es durch Klicken auf die Schaltfläche ![](/basics/edit_add.png) möglich, vorhandene QLC+-Funktionen zu importieren und zur Show-Timeline hinzuzufügen.  
+Ein neues Element wird an der Cursorposition platziert, es ist jedoch jederzeit möglich, es an die gewünschte Zeit zu verschieben, indem Sie es einfach entlang der Zeitleiste ziehen.  
+Ein Element kann nicht in eine andere Spur verschoben werden, da es an die Spur gebunden ist, in der es ursprünglich erstellt wurde.  
+Mit den Symbolleistensymbolen kann ein Element kopiert ![](/basics/editcopy.png), eingefügt ![](/basics/editpaste.png) oder gelöscht ![](/basics/editdelete.png) werden. Das eingefügte Element wird an der aktuellen Cursorposition platziert.  
+Die Hintergrundfarbe des Elements kann mit dem Symbolleistensymbol ![](/basics/color.png) geändert werden. Die zugewiesene Farbe wird in Ihrer Projektdatei gespeichert.  
 Sobald ein Element ausgewählt ist, wird auf der rechten Seite des Bildschirms sein spezifischer Funktionseditor angezeigt. Wenn Sie mit der rechten Maustaste auf ein Element klicken, wird ein Kontextmenü mit den folgenden Optionen angezeigt:
 
 * **Vorschau**: Diese Option ist nur für Audioelemente verfügbar. Es wird die Wellenformvorschau für den rechten, linken oder Stereokanal angezeigt, sofern verfügbar
 * **Am Cursor ausrichten**: Diese Option verschiebt das ausgewählte Element an die Cursorposition
 * ![](/basics/lock.png)**Sperren/Entsperren**: Sobald ein Element gesperrt ist, kann es nicht mehr auf der Timeline gezogen werden
 
-Befolgen Sie Schritt 4, um zu verstehen, wie eine Sequenz gefüllt wird
+Befolgen Sie Schritt 4, um zu verstehen, wie eine Sequenz gefüllt wird.  
 
 #### 4. Bearbeiten Sie Ihre Funktionen
 
-Sobald ein Element erstellt wurde, ist es nun an der Zeit, es zu bearbeiten.
-**Bitte beachten Sie**, dass der Unterschied zwischen einem Chaser und einer Sequenz darin besteht, dass eine Sequenz an die Spur (also die Szene) gebunden ist, in der sie erstellt wurde. Wenn Sie also einen Schritt hinzufügen, fordert QLC+ nicht zur Auswahl einer bestimmten Funktion auf, sondern verwendet immer die Kanäle derselben Szene.
-Wenn Sie eine Funktion bearbeiten, sehen Sie, wie sich das Element in der Multitrack-Ansicht ändert, und geben eine sofortige Rückmeldung zur Ausrichtung auf andere Elemente oder bestimmte Zeitpunkte.
-Ein- und Ausblendzeiten werden als diagonale Linien über den Elementen in der Multitrack-Ansicht angezeigt, während verschiedene Schritte/Loops durch vertikale Linien unterteilt werden.
+Sobald ein Element erstellt wurde, ist es nun an der Zeit, es zu bearbeiten.  
+**Bitte beachten Sie**, dass der Unterschied zwischen einem Chaser und einer Sequenz darin besteht, dass eine Sequenz an die Spur (also die Szene) gebunden ist, in der sie erstellt wurde. Wenn Sie also einen Schritt hinzufügen, fordert QLC+ nicht zur Auswahl einer bestimmten Funktion auf, sondern verwendet immer die Kanäle derselben Szene.  
+Wenn Sie eine Funktion bearbeiten, sehen Sie, wie sich das Element in der Multitrack-Ansicht ändert, und geben eine sofortige Rückmeldung zur Ausrichtung auf andere Elemente oder bestimmte Zeitpunkte.  
+Ein- und Ausblendzeiten werden als diagonale Linien über den Elementen in der Multitrack-Ansicht angezeigt, während verschiedene Schritte/Loops durch vertikale Linien unterteilt werden.  
 
 
-Um die Komplexität der Show zu erhöhen, können weitere Funktionen hinzugefügt werden. Wiederholen Sie einfach die oben genannten Schritte je nach Bedarf.
+Um die Komplexität der Show zu erhöhen, können weitere Funktionen hinzugefügt werden. Wiederholen Sie einfach die oben genannten Schritte je nach Bedarf.  
 
 Und schließlich...spielen! ![](/basics/player_play.png)
 ---------------------------------------------
 
-Wenn schließlich eine komplette Show erstellt wurde, kann diese einfach durch Klicken auf das Play-Symbol abgespielt werden.
+Wenn schließlich eine komplette Show erstellt wurde, kann diese einfach durch Klicken auf das Play-Symbol abgespielt werden.  
 Die Wiedergabe beginnt immer an der aktuellen Cursorposition. Die Cursorposition kann durch Klicken auf die Zeitleiste geändert werden.

--- a/pages/06.simple-desk/chapter.v4_de.md
+++ b/pages/06.simple-desk/chapter.v4_de.md
@@ -14,12 +14,12 @@ taxonomy:
 
 # Einfache Arbeitsoberfläche
 
-Das einfache Pult emuliert eine typische Lichtkonsole, die ein vollständiges 512-Kanal-DMX-Universum mit mehreren Cue-Stacks steuern kann, die mit Wiedergabe-Schiebereglern bedient werden.
-Der einfache Schreibtisch ist in zwei Hauptbereiche unterteilt: **Kanäle** (oberer Bereich) und **Hinweise** (unterer Bereich).
-Der Kanalbereich spiegelt genau den aktuellen Status jedes DMX-Kanals jedes Universums wider. Wenn Kanäle gesteuert werden, ohne dass ein Projekt geladen ist, können Benutzer sie vollständig manuell steuern.
-Wenn ein Projekt geladen ist, überschreibt das Verschieben eines Simple-Desk-Kanals alle anderen QLC+-Funktionen, die versuchen, diesen Kanal zu steuern. Eine visuelle Anzeige färbt den Hintergrund des Kanals rot und informiert den Benutzer darüber, dass Simple Desk nun die vollständige Kontrolle darüber hat.
-Dies ist in einigen Live-Umständen sehr nützlich, in denen eine laufende Funktion eine manuelle Anpassung erfordert.
-Um Simple Desk von übergeordneten Kanälen zu „deaktivieren“, klicken Sie einfach auf die Schaltfläche „Zurücksetzen“. Durch das Zurücksetzen von Kanälen werden diese entweder auf Null oder auf den zuvor durch eine Funktion festgelegten Wert zurückgesetzt.
+Das einfache Pult emuliert eine typische Lichtkonsole, die ein vollständiges 512-Kanal-DMX-Universum mit mehreren Cue-Stacks steuern kann, die mit Wiedergabe-Schiebereglern bedient werden.  
+Der einfache Schreibtisch ist in zwei Hauptbereiche unterteilt: **Kanäle** (oberer Bereich) und **Hinweise** (unterer Bereich).  
+Der Kanalbereich spiegelt genau den aktuellen Status jedes DMX-Kanals jedes Universums wider. Wenn Kanäle gesteuert werden, ohne dass ein Projekt geladen ist, können Benutzer sie vollständig manuell steuern.  
+Wenn ein Projekt geladen ist, überschreibt das Verschieben eines Simple-Desk-Kanals alle anderen QLC+-Funktionen, die versuchen, diesen Kanal zu steuern. Eine visuelle Anzeige färbt den Hintergrund des Kanals rot und informiert den Benutzer darüber, dass Simple Desk nun die vollständige Kontrolle darüber hat.  
+Dies ist in einigen Live-Umständen sehr nützlich, in denen eine laufende Funktion eine manuelle Anpassung erfordert.  
+Um Simple Desk von übergeordneten Kanälen zu „deaktivieren“, klicken Sie einfach auf die Schaltfläche „Zurücksetzen“. Durch das Zurücksetzen von Kanälen werden diese entweder auf Null oder auf den zuvor durch eine Funktion festgelegten Wert zurückgesetzt.  
 
 Cues arbeitet getrennt von anderen QLC+-Komponenten. Beispielsweise sind Hinweise innerhalb des Hinweisstapels im [Funktionsmanager](/function-manager) nicht sichtbar und [Szenen](/basics/glossary-and-concepts#szene) sind im Hinweisstapel nicht sichtbar.
 

--- a/pages/07.virtual-console/03.slider/default.v4_de.md
+++ b/pages/07.virtual-console/03.slider/default.v4_de.md
@@ -44,11 +44,11 @@ Wenn sich der Schieberegler derzeit nicht im Level-Modus befindet, sehen Sie led
 
 ### Konfiguration – Registerkarte „Wiedergabe“.
 
-Wenn sich der Schieberegler derzeit nicht im Wiedergabemodus befindet, sehen Sie lediglich eine Schaltfläche, die Sie auffordert, darauf zu klicken, um in den Wiedergabemodus zu wechseln. Nachdem Sie darauf geklickt haben, werden die Eigenschaften des Wiedergabemodus angezeigt.
+Wenn sich der Schieberegler derzeit nicht im Wiedergabemodus befindet, sehen Sie lediglich eine Schaltfläche, die Sie auffordert, darauf zu klicken, um in den Wiedergabemodus zu wechseln. Nachdem Sie darauf geklickt haben, werden die Eigenschaften des Wiedergabemodus angezeigt.  
 
 Wenn sich der Schieberegler im Wiedergabemodus befindet, verhält er sich wie eine Kombination aus Schaltfläche und Schieberegler. Mit dem Schieberegler können Sie eine Funktion starten UND gleichzeitig die Intensität der Funktion steuern. Wenn der Schieberegler auf Null steht, wird die Funktion gestoppt, aber jeder Wert über Null startet die Funktion (sofern sie nicht bereits gestartet wurde) und passt gleichzeitig die Intensität der Funktion an (falls zutreffend).
 
-Ein Schieberegler im Wiedergabemodus ignoriert die Ein- und Ausblendzeiten der angehängten Funktion, sodass Überblendungen manuell durchgeführt werden müssen.
+Ein Schieberegler im Wiedergabemodus ignoriert die Ein- und Ausblendzeiten der angehängten Funktion, sodass Überblendungen manuell durchgeführt werden müssen.  
 Wenn Sie Ein-/Ausblendautomatisierungen zusammen mit der Steuerung der Funktionsintensität benötigen, ist die Verwendung eines ![](/basics/button.png)[Virtual Console Button](../button) in Kombination mit einem Slider in Der Submaster-Modus ist genau das, wonach Sie suchen.
 
 |     |     |
@@ -62,7 +62,7 @@ Wenn Sie Ein-/Ausblendautomatisierungen zusammen mit der Steuerung der Funktions
 
 Wenn sich der Schieberegler derzeit nicht im Submaster-Modus befindet, sehen Sie lediglich eine Schaltfläche, die Sie auffordert, darauf zu klicken, um in den Submaster-Modus zu wechseln. Nachdem Sie darauf geklickt haben, wird der Schieberegler so eingestellt, dass er als Submaster fungiert.
 
-Wenn ein Schieberegler auf den Submaster-Modus eingestellt ist, steuert er die Intensität jedes anderen Widgets im selben Frame (bitte beachten Sie, dass der Hauptbereich der virtuellen Konsole ebenfalls ein Frame ist!)
-Die Intensität eines Widgets hängt von der Art des Widgets selbst und der damit gesteuerten Funktionalität ab. Ein Submaster steuert die Intensität jeder „lichtemittierenden“ QLC+-Funktionalität, entweder einer Funktion oder einzelner Kanalebenen.
-Beispielsweise kann ein Submaster die Intensität einer Funktion steuern, die einer [Schaltfläche](../button) zugeordnet ist, oder die Kanalpegel, die einem Schieberegler im Pegelmodus zugeordnet sind.
+Wenn ein Schieberegler auf den Submaster-Modus eingestellt ist, steuert er die Intensität jedes anderen Widgets im selben Frame (bitte beachten Sie, dass der Hauptbereich der virtuellen Konsole ebenfalls ein Frame ist!)  
+Die Intensität eines Widgets hängt von der Art des Widgets selbst und der damit gesteuerten Funktionalität ab. Ein Submaster steuert die Intensität jeder „lichtemittierenden“ QLC+-Funktionalität, entweder einer Funktion oder einzelner Kanalebenen.  
+Beispielsweise kann ein Submaster die Intensität einer Funktion steuern, die einer [Schaltfläche](../button) zugeordnet ist, oder die Kanalpegel, die einem Schieberegler im Pegelmodus zugeordnet sind.  
 Jedes Widget wird von einem Submaster gesteuert, auch wenn die Funktionalität des Widgets noch nicht aktiv ist. Wenn beispielsweise ein Submaster auf 50 % eingestellt ist, startet ein anschließender Tastendruck die zugehörige Funktion mit 50 % Intensität.

--- a/pages/07.virtual-console/05.animation/default.v4_de.md
+++ b/pages/07.virtual-console/05.animation/default.v4_de.md
@@ -3,23 +3,23 @@ title: Animationen
 date: '03:09 22-08-2023'
 ---
 
-Ein Animations-Widget ist ein vollständiges Werkzeug zum Arbeiten mit den [RGB-Matrizen](/basics/glossary-and-concepts#rgb-matrix) Ihres Projekts.
-Es zeigt mehrere grafische Elemente an, um eine Matrix während Live-Shows vollständig zu steuern.
+Ein Animations-Widget ist ein vollständiges Werkzeug zum Arbeiten mit den [RGB-Matrizen](/basics/glossary-and-concepts#rgb-matrix) Ihres Projekts.  
+Es zeigt mehrere grafische Elemente an, um eine Matrix während Live-Shows vollständig zu steuern.  
 Am wichtigsten ist, dass Sie damit eine Reihe sogenannter „benutzerdefinierter Steuerelemente“ definieren können, um Voreinstellungen, Farben und Eigenschaften schnell abzurufen und sofort auf eine laufende Matrix anzuwenden.
 
 Einführung
 ------------
 
-Wenn Sie auf das Symbol ![](/basics/animation.png) klicken, wird Ihrer virtuellen Konsole ein Animations-Widget hinzugefügt.
-Standardmäßig zeigt das Widget 4 Elemente an:
+Wenn Sie auf das Symbol ![](/basics/animation.png) klicken, wird Ihrer virtuellen Konsole ein Animations-Widget hinzugefügt.  
+Standardmäßig zeigt das Widget vier Elemente an:
 
-* Ganz links ein Schieberegler zur Steuerung der Wiedergabe und der Intensität einer RGB-Matrix.
-    Die Schiebereglerbewegung kann einer externen Controller-Eingangsleitung zugeordnet werden.
+* Ganz links ein Schieberegler zur Steuerung der Wiedergabe und der Intensität einer RGB-Matrix.  
+    Die Schiebereglerbewegung kann einer externen Controller-Eingangsleitung zugeordnet werden.  
     Es verhält sich im Wiedergabemodus genau wie ein [Virtual Console Slider](../slider).
 * Oben rechts zwei [Click & Go](/basics/glossary-and-concepts#click-and-go)-Schaltflächen zum Festlegen der Start- und Endfarbe der Matrix. Wenn Sie im [Betriebsmodus](/basics/glossary-and-concepts#modi) darauf klicken, wird ein Farbauswahlmenü angezeigt.
 * Unterhalb der beiden Schaltflächen befindet sich ein Dropdown-Menü zur Auswahl der gewünschten Matrix-Animation oder Voreinstellung.
 
-Der Platz unter dem Animationsmenü ist für benutzerdefinierte Steuerelemente reserviert. Sie können im Widget-Konfigurationsfenster definiert werden und werden jeweils als einzelne Schaltfläche angezeigt.
+Der Platz unter dem Animationsmenü ist für benutzerdefinierte Steuerelemente reserviert. Sie können im Widget-Konfigurationsfenster definiert werden und werden jeweils als einzelne Schaltfläche angezeigt.  
 Jedes benutzerdefinierte Steuerelement kann einer Tastenkombination oder einer externen Controller-Eingabezeile zugeordnet werden.
 
 Konfiguration
@@ -38,9 +38,9 @@ Ein Animations-Widget kann mit der Schaltfläche „Eigenschaften“ ![](/basics
 
 ### Seite „Benutzerdefinierte Steuerelemente“.
 
-Ein benutzerdefiniertes Steuerelement ist eine „Verknüpfung“ zu einer Funktionalität einer RGB-Matrix.
-Grundsätzlich können Sie während der Designphase einer Show alle Optionen steuern, die normalerweise im [RGB-Matrix-Editor](/function-manager/rgb-matrix-editor) verwendet werden. Die einzige Option, die Sie nicht steuern können, ist die Fixture-Gruppe, die von einer RGB-Matrixfunktion verwendet wird.
-Auf dieser Konfigurationsseite kann der Benutzer je nach Bedarf während einer Live-Aufführung eine beliebige Anzahl benutzerdefinierter Steuerelemente definieren.
+Ein benutzerdefiniertes Steuerelement ist eine „Verknüpfung“ zu einer Funktionalität einer RGB-Matrix.  
+Grundsätzlich können Sie während der Designphase einer Show alle Optionen steuern, die normalerweise im [RGB-Matrix-Editor](/function-manager/rgb-matrix-editor) verwendet werden. Die einzige Option, die Sie nicht steuern können, ist die Fixture-Gruppe, die von einer RGB-Matrixfunktion verwendet wird.  
+Auf dieser Konfigurationsseite kann der Benutzer je nach Bedarf während einer Live-Aufführung eine beliebige Anzahl benutzerdefinierter Steuerelemente definieren.  
 Jedes benutzerdefinierte Steuerelement wird als Schaltfläche im Layout des Animations-Widgets dargestellt und kann entweder mit der Maus angeklickt oder auf einem Touchscreen gedrückt oder einer Tastenkombination oder einer externen Controller-Eingabezeile zugeordnet werden.
 
 |     |     |

--- a/pages/07.virtual-console/06.speed-dial/default.v4_de.md
+++ b/pages/07.virtual-console/06.speed-dial/default.v4_de.md
@@ -96,8 +96,8 @@ Hier kann ausgewählt werden, ob der Multiplikationsfaktor zurückgesetzt werden
 
 ### Konfiguration – Registerkarte „Voreinstellungen“
 
-Eine Voreinstellung ist eine Möglichkeit, schnell auf einen vordefinierten Wert für eine Kurzwahl zuzugreifen.
-Jede Voreinstellung wird im Kurzwahl-Widget-Layout als Schaltfläche dargestellt und kann entweder mit der Maus angeklickt oder auf einem Touchscreen gedrückt oder einer Tastenkombination oder einer externen Controller-Eingabezeile zugeordnet werden.
+Eine Voreinstellung ist eine Möglichkeit, schnell auf einen vordefinierten Wert für eine Kurzwahl zuzugreifen.  
+Jede Voreinstellung wird im Kurzwahl-Widget-Layout als Schaltfläche dargestellt und kann entweder mit der Maus angeklickt oder auf einem Touchscreen gedrückt oder einer Tastenkombination oder einer externen Controller-Eingabezeile zugeordnet werden.  
 Links auf der Registerkarte „Voreinstellungen“ befindet sich die Liste der Voreinstellungen. Wenn Sie in dieser Liste eine Voreinstellung auswählen, können Sie über die Schaltfläche rechts deren Eigenschaften bearbeiten.
 
 |     |     |

--- a/pages/07.virtual-console/07.xy-pad/default.v4.md
+++ b/pages/07.virtual-console/07.xy-pad/default.v4.md
@@ -64,7 +64,7 @@ The XY Pad allows 3 completely different usages, but all targeted to positioning
   
 * **2- EFX**: In the Configuration window (Presets tab), it is possible to add some presets to recall existing ![](/basics/efx.png) [EFX](/basics/glossary-and-concepts#efx) functions. When activating a EFX preset, the animated preview of the fixtures movements will be displayed like this:  
     ![](xypad-efx.png)  
-    If no working window is set, the EFX will be be displayed exactly like it is previewed in the [EFX Editor](/function-manager/efx-editor). Otherwise, the EFX will be scaled to fit the defined working window.
+    If no working window is set, the EFX will be be displayed exactly like it is previewed in the [EFX Editor](/function-manager/efx-editor). Otherwise, the EFX will be scaled to fit the defined working window.  
     If a working window is active, it will be shared between usage #1 and usage #2.
   
 * **3- Relative to a Scene**: In the Configuration window (Presets tab), it is also possible to add some presets to recall existing ![](/basics/scene.png) [Scene](/basics/glossary-and-concepts#scene) functions  

--- a/pages/07.virtual-console/07.xy-pad/default.v4_de.md
+++ b/pages/07.virtual-console/07.xy-pad/default.v4_de.md
@@ -4,9 +4,9 @@ date: '03:22 22-08-2023'
 media_order: 'xypad.png,xypad2.png,xypad-efx.png'
 ---
 
-XY Pad ist ein virtuelles Konsolen-Widget zur Positionierung von Vorrichtungen.
-Es kann die typischen DMX-Bewegungskanäle (**Pan** und **Tilt**) intelligenter Beleuchtungsgeräte, nämlich Scanner und Moving Heads, verarbeiten.
-Das Pad ist ein in der Größe veränderbarer Bereich, der von mehreren Bedienelementen umgeben ist, um die Anforderungen zu erfüllen, die Sie möglicherweise während einer Live-Show haben.
+XY-Pad ist ein virtuelles Konsolen-Widget zur Positionierung von Vorrichtungen.  
+Es kann die typischen DMX-Bewegungskanäle (**Pan** und **Tilt**) intelligenter Beleuchtungsgeräte, nämlich Scanner und Moving Heads, verarbeiten.  
+Das Pad ist ein in der Größe veränderbarer Bereich, der von mehreren Bedienelementen umgeben ist, um die Anforderungen zu erfüllen, die Sie möglicherweise während einer Live-Show haben.  
 Es wird wie folgt angezeigt:
 
 ![](xypad.png)
@@ -27,25 +27,25 @@ Es wird wie folgt angezeigt:
 
 ### Begrenzung des Arbeitsbereichs
 
-Das XY-Pad ist im Grunde eine Karte des gesamten Gradbereichs, den die Schwenk- und Neigungskanäle Ihrer Geräte verwalten können.
+Das XY-Pad ist im Grunde eine Karte des gesamten Gradbereichs, den die Schwenk- und Neigungskanäle Ihrer Geräte verwalten können.  
 Hier ist ein Bild, das zeigt, wie der Hauptbereich normalerweise Grade darstellt:
 
 ![](xypad2.png)
 
-Es gibt jedoch Fälle, in denen Sie den Grad begrenzen möchten, den ein beweglicher Kopf oder ein Scanner erreichen kann.
-Beispielsweise sollten Geräte mit einem Schwenkbereich von 540 Grad darauf beschränkt sein, nur in einem Bereich zu arbeiten, der dem Publikum zugewandt ist, oder Sie möchten möglicherweise vermeiden, dass bewegte Köpfe, die verkehrt herum an einer Traverse montiert sind, zur Decke oder außerhalb der Bühne zeigen.
+Es gibt jedoch Fälle, in denen Sie den Grad begrenzen möchten, den ein beweglicher Kopf oder ein Scanner erreichen kann.  
+Beispielsweise sollten Geräte mit einem Schwenkbereich von 540 Grad darauf beschränkt sein, nur in einem Bereich zu arbeiten, der dem Publikum zugewandt ist, oder Sie möchten möglicherweise vermeiden, dass bewegte Köpfe, die verkehrt herum an einer Traverse montiert sind, zur Decke oder außerhalb der Bühne zeigen.  
 Mit dem XY-Pad gibt es zwei Möglichkeiten, dies zu erreichen:
 
 **1\. Arbeitsfenster**
 
-Mit den Schiebereglern für den oberen und linken Bereich **(1)** ist es möglich, den Bereich einzuschränken, in dem das XY-Pad funktioniert.
-Wenn Sie den Bereich dieser Schieberegler reduzieren, wird ein halbtransparenter grüner Bereich **(7)** über dem Hauptbereich hervorgehoben, um die X/Y-Grenzen zu markieren, an denen Ihre Geräte arbeiten sollen.
+Mit den Schiebereglern für den oberen und linken Bereich **(1)** ist es möglich, den Bereich einzuschränken, in dem das XY-Pad funktioniert.  
+Wenn Sie den Bereich dieser Schieberegler reduzieren, wird ein halbtransparenter grüner Bereich **(7)** über dem Hauptbereich hervorgehoben, um die X/Y-Grenzen zu markieren, an denen Ihre Geräte arbeiten sollen.  
 Beachten Sie, dass bei Verwendung einer Maus auf der Benutzeroberfläche die Bewegung der Griffe auf das Arbeitsfenster beschränkt ist, auch wenn Sie den Cursor außerhalb davon ziehen, während bei Verwendung eines externen Controllers alle Werte auf das Fenster skaliert werden. Dadurch können Sie den gesamten Bereich eines physischen Faders nutzen und haben so eine höhere Empfindlichkeit beim Einstellen einer Position.
 
 **2\. Individuelles Leuchtenprogramm**
 
-Es ist möglich, im Eigenschaftendialog für jedes Gerät einen bestimmten Bereich festzulegen (siehe Abschnitt **Konfiguration**). Bei dieser Methode wird der gesamte Hauptbereich **(8)** genutzt und jeder angegebene Bereich jedes Geräts darauf skaliert.
-Dies ist sehr praktisch, wenn Sie ein XY-Pad mit gemischten Vorrichtungen und unterschiedlichen Gradbereichen verwenden möchten.
+Es ist möglich, im Eigenschaftendialog für jedes Gerät einen bestimmten Bereich festzulegen (siehe Abschnitt **Konfiguration**). Bei dieser Methode wird der gesamte Hauptbereich **(8)** genutzt und jeder angegebene Bereich jedes Geräts darauf skaliert.  
+Dies ist sehr praktisch, wenn Sie ein XY-Pad mit gemischten Vorrichtungen und unterschiedlichen Gradbereichen verwenden möchten.  
 
 Beispielsweise können Sie ein Gerät mit einer Schwenkbewegung von 540 Grad genau wie eines mit einer Schwenkbewegung von 360 Grad veranlassen.
 
@@ -55,24 +55,24 @@ Es ist möglich, beide Grenzwerte zu aktivieren (mithilfe der Bereichsschiebereg
 
 ### XY-Pad-Verwendungen
 
-Das XY-Pad ermöglicht drei völlig unterschiedliche Verwendungsmöglichkeiten, die jedoch alle auf die Positionierung ausgerichtet sind. Es liegt an Ihnen, je nach Ihren Bedürfnissen zu entscheiden, wie Sie sie am besten nutzen. Möglicherweise möchten Sie auch die Verwendung mehrerer XY-Pads für unterschiedliche Zwecke in Betracht ziehen.
+Das XY-Pad ermöglicht drei völlig unterschiedliche Verwendungsmöglichkeiten, die jedoch alle auf die Positionierung ausgerichtet sind. Es liegt an Ihnen, je nach Ihren Bedürfnissen zu entscheiden, wie Sie sie am besten nutzen. Möglicherweise möchten Sie auch die Verwendung mehrerer XY-Pads für unterschiedliche Zwecke in Betracht ziehen.  
 
-* **1- Absolute Positionierung**: Dies ist die grundlegende Verwendung und erfordert lediglich die Angabe, welche Geräte Sie steuern möchten (hinzugefügt über das Konfigurationsfenster) und schließlich deren spezifischen Betriebsbereich.
-    Wie bereits beschrieben, müssen Sie lediglich Ihre Geräte einmal einrichten und mit dem Bewegen mit Ihrem bevorzugten Controller beginnen.
-    Es ist auch möglich, einige Positionsvoreinstellungen zu definieren, sodass in **(9)** eine Reihe von Schaltflächen angezeigt werden, um schnell eine absolute Position abzurufen.
+* **1- Absolute Positionierung**: Dies ist die grundlegende Verwendung und erfordert lediglich die Angabe, welche Geräte Sie steuern möchten (hinzugefügt über das Konfigurationsfenster) und schließlich deren spezifischen Betriebsbereich.  
+    Wie bereits beschrieben, müssen Sie lediglich Ihre Geräte einmal einrichten und mit dem Bewegen mit Ihrem bevorzugten Controller beginnen.  
+    Es ist auch möglich, einige Positionsvoreinstellungen zu definieren, sodass in **(9)** eine Reihe von Schaltflächen angezeigt werden, um schnell eine absolute Position abzurufen.  
     Wenn eine Fixture-Gruppen-Voreinstellung aktiviert ist, steuert das XY-Pad nur die absoluten Positionen der in der Voreinstellung definierten Fixtures. (Weitere Informationen finden Sie auf der Registerkarte „Voreinstellungen“).
 
-* **2- EFX**: Im Konfigurationsfenster (Registerkarte „Voreinstellungen“) ist es möglich, einige Voreinstellungen hinzuzufügen, um vorhandene ![](/basics/efx.png) [EFX](/basics/glossary-and-concepts#efx) Funktionen. Wenn Sie ein EFX-Preset aktivieren, wird die animierte Vorschau der Fixture-Bewegungen wie folgt angezeigt:
+* **2- EFX**: Im Konfigurationsfenster (Registerkarte „Voreinstellungen“) ist es möglich, einige Voreinstellungen hinzuzufügen, um vorhandene ![](/basics/efx.png) [EFX](/basics/glossary-and-concepts#efx) Funktionen. Wenn Sie ein EFX-Preset aktivieren, wird die animierte Vorschau der Fixture-Bewegungen wie folgt angezeigt:  
     ![](xypad-efx.png)
-    Wenn kein Arbeitsfenster festgelegt ist, wird der EFX genau so angezeigt, wie er im [EFX-Editor](/function-manager/efx-editor) in der Vorschau angezeigt wird. Andernfalls wird der EFX so skaliert, dass er in das definierte Arbeitsfenster passt.
+    Wenn kein Arbeitsfenster festgelegt ist, wird der EFX genau so angezeigt, wie er im [EFX-Editor](/function-manager/efx-editor) in der Vorschau angezeigt wird. Andernfalls wird der EFX so skaliert, dass er in das definierte Arbeitsfenster passt.  
     Wenn ein Arbeitsfenster aktiv ist, wird es zwischen Nutzung Nr. 1 und Nutzung Nr. 2 geteilt.
 
-* **3- Relativ zu einer Szene**: Im Konfigurationsfenster (Registerkarte „Voreinstellungen“) ist es auch möglich, einige Voreinstellungen hinzuzufügen, um vorhandene ![](/basics/scene.png) [Szenen](/basics/glossary-and-concepts#szene)-Funktionen abzurufen
-    Das XY-Pad erkennt, welche Schwenk-/Neigekanäle in der Szene vorhanden sind, und stellt sie ein.
-    Der Pad-Griff **(6)** positioniert sich automatisch in der Mitte des Hauptbereichs **(8)**. Durch Bewegen des Griffs werden relative Werte aus der Mitte des Pads erzeugt, die zu den DMX-Werten der laufenden Szene addiert/subtrahiert werden.
-    Wenn Sie nach oben bewegen, wird ein negativer Offset zu den Neigungskanälen hinzugefügt, und wenn Sie nach unten gehen, wird ein positiver Offset hinzugefügt.
-    Durch Bewegen nach links wird ein negativer Offset zu den Pan-Kanälen hinzugefügt, durch Bewegen nach rechts wird ein positiver Offset hinzugefügt.
-    Wenn beim Aktivieren einer Szenenvoreinstellung ein Arbeitsfenster aktiv ist, wird es ausgeblendet, da es bei dieser Verwendung keine absoluten Werte gibt. Beim Zurückschalten auf Verwendung Nr. 1 oder Nr. 2 wird das Arbeitsfenster wiederhergestellt.
+* **3- Relativ zu einer Szene**: Im Konfigurationsfenster (Registerkarte „Voreinstellungen“) ist es auch möglich, einige Voreinstellungen hinzuzufügen, um vorhandene ![](/basics/scene.png) [Szenen](/basics/glossary-and-concepts#szene)-Funktionen abzurufen.  
+    Das XY-Pad erkennt, welche Schwenk-/Neigekanäle in der Szene vorhanden sind, und stellt sie ein.  
+    Der Pad-Griff **(6)** positioniert sich automatisch in der Mitte des Hauptbereichs **(8)**. Durch Bewegen des Griffs werden relative Werte aus der Mitte des Pads erzeugt, die zu den DMX-Werten der laufenden Szene addiert/subtrahiert werden.  
+    Wenn Sie nach oben bewegen, wird ein negativer Offset zu den Neigungskanälen hinzugefügt, und wenn Sie nach unten gehen, wird ein positiver Offset hinzugefügt.  
+    Durch Bewegen nach links wird ein negativer Offset zu den Pan-Kanälen hinzugefügt, durch Bewegen nach rechts wird ein positiver Offset hinzugefügt.  
+    Wenn beim Aktivieren einer Szenenvoreinstellung ein Arbeitsfenster aktiv ist, wird es ausgeblendet, da es bei dieser Verwendung keine absoluten Werte gibt. Beim Zurückschalten auf Verwendung Nr. 1 oder Nr. 2 wird das Arbeitsfenster wiederhergestellt.  
     Bitte beachten Sie, dass bei Aktivierung einer Szenenvoreinstellung tatsächlich die gesamte Szene gestartet wird, mit Farben und allem. In diesem Fall wird empfohlen, Szenen nur mit aktivierten Schwenk-/Neigekanälen zu erstellen und kein XY-Pad für andere Zwecke zu verwenden.
 
 ### Tastatursteuerung
@@ -92,7 +92,7 @@ XY-Pads können mit der Schaltfläche „Eigenschaften“ ![](/basics/edit.png) 
 
 **1\. Registerkarte „Allgemein“**
 
-Hier können Sie das grundlegende Verhalten des XY-Pads sowie die externen Eingabesteuerungen festlegen.
+Hier können Sie das grundlegende Verhalten des XY-Pads sowie die externen Eingabesteuerungen festlegen.  
 **Hinweis:** Wenn Sie über Touch OSC ein XY-Pad zuweisen, müssen Sie auf die Schaltfläche „Neigung/vertikale Achse“ zur automatischen Erkennung klicken, andernfalls werden die X- und Y-Achsen vertauscht.
 
 |     |     |

--- a/pages/07.virtual-console/08.cue-list/default.v4_de.md
+++ b/pages/07.virtual-console/08.cue-list/default.v4_de.md
@@ -11,7 +11,7 @@ In der ersten Spalte der Cue-Liste wird die Cue-Nummer angezeigt, die von 1 bis 
 
 ### Konfiguration
 
-Cue-Listen können mit der Objekteigenschaften-Schaltfläche ![](/basics/edit.png) in der Symbolleiste oder durch Doppelklick auf das Cue-List-Widget konfiguriert werden.
+Cue-Listen können mit der Objekteigenschaften-Schaltfläche ![](/basics/edit.png) in der Symbolleiste oder durch Doppelklick auf das Cue-List-Widget konfiguriert werden.  
 
 |     |     |
 | --- | --- |
@@ -26,11 +26,11 @@ Cue-Listen können mit der Objekteigenschaften-Schaltfläche ![](/basics/edit.pn
 
 ### Betriebsmodus
 
-Wenn Sie QLC+ in den [Betriebsmodus](/basics/glossary-and-concepts#modi) schalten, wird die Cue-Liste aktiv und ermöglicht die Auswahl der gewünschten Cues, die im zugehörigen Chaser enthalten sind.
+Wenn Sie QLC+ in den [Betriebsmodus](/basics/glossary-and-concepts#modi) schalten, wird die Cue-Liste aktiv und ermöglicht die Auswahl der gewünschten Cues, die im zugehörigen Chaser enthalten sind.  
 
-Durch Drücken der ENTER-Taste wird der ausgewählte Cue gestartet.
+Durch Drücken der ENTER-Taste wird der ausgewählte Cue gestartet.  
 
-Die folgenden Elemente werden unten im Cue-List-Widget angezeigt:
+Die folgenden Elemente werden unten im Cue-List-Widget angezeigt:  
 
 
 |     |     |
@@ -45,15 +45,15 @@ Die folgenden Elemente werden unten im Cue-List-Widget angezeigt:
 
 ### Überblendung
 
-Mit dem Seitenfader kann die Überblendung zwischen zwei aufeinanderfolgenden Cues manuell gesteuert werden.
+Mit dem Seitenfader kann die Überblendung zwischen zwei aufeinanderfolgenden Cues manuell gesteuert werden.  
 
-Die Zahlen oben und unten am Fader zeigen den „aktuellen Cue“ und den „nächsten Cue“ an.
-Die Beschriftung des aktuellen Cues ist blau. Dieser liegt bei 100 %, wenn die Wiedergabe der Cue-Liste gestartet wird.
-Die Beschriftung für den nächsten Cue ist orangefarben und steht bei 0 %, wenn die Wiedergabe der Cue-Liste gestartet wird.
+Die Zahlen oben und unten am Fader zeigen den „aktuellen Cue“ und den „nächsten Cue“ an.  
+Die Beschriftung des aktuellen Cues ist blau. Dieser liegt bei 100 %, wenn die Wiedergabe der Cue-Liste gestartet wird.  
+Die Beschriftung für den nächsten Cue ist orangefarben und steht bei 0 %, wenn die Wiedergabe der Cue-Liste gestartet wird.  
 
-Wenn die Cue-Liste ausgeführt wird, steuert der Crossfade-Fader die Intensität der zugehörigen Cues, indem er deren Ein- und Ausblendgeschwindigkeiten außer Kraft setzt und so eine manuelle Steuerung des Übergangs ermöglicht.
+Wenn die Cue-Liste ausgeführt wird, steuert der Crossfade-Fader die Intensität der zugehörigen Cues, indem er deren Ein- und Ausblendgeschwindigkeiten außer Kraft setzt und so eine manuelle Steuerung des Übergangs ermöglicht.  
 
-Nachdem der Fader an das entgegengesetzte Ende seines Weges bewegt wurde, finden folgende Änderungen statt:
+Nachdem der Fader an das entgegengesetzte Ende seines Weges bewegt wurde, finden folgende Änderungen statt:  
 
 * Die orangefarbene Beschriftung des nächsten Cues wechselt zu Blau. Dies zeigt an, dass der alte nächste Cue zum neuen aktuellen Cue geworden ist.
 * Die blaue Beschriftung des aktuellen Cues wechselt zu Orange und die Nummer des Cues wird um 2 erhöht. Dieser Fader steuert nun den Cue, der nach dem alten nächsten Cue kommt.
@@ -62,6 +62,6 @@ Nachdem der Fader an das entgegengesetzte Ende seines Weges bewegt wurde, finden
 
 ### Hinweis
 
-Wenn ein Cue mithilfe des [Chaser-Editors](/function-manager/chaser-editor) zu einem Chaser hinzugefügt wird, wird die Standarddauer auf 0 gesetzt.
-Um zu vermeiden, dass die Cues in der Cue-Liste hektisch und ohne Ergebnis wiederholt werden, legen Sie die Dauer Ihrer Cues fest, indem Sie entweder auf das Dauerfeld doppelklicken oder das Kurzwahl-Widget verwenden![](/basics/speed.png)
+Wenn ein Cue mithilfe des [Chaser-Editors](/function-manager/chaser-editor) zu einem Chaser hinzugefügt wird, wird die Standarddauer auf 0 gesetzt.  
+Um zu vermeiden, dass die Cues in der Cue-Liste hektisch und ohne Ergebnis wiederholt werden, legen Sie die Dauer Ihrer Cues fest, indem Sie entweder auf das Dauerfeld doppelklicken oder das Kurzwahl-Widget verwenden![](/basics/speed.png)  
 Beachten Sie, dass Sie, wenn Sie Szenen benötigen, die Sie manuell mit dem Cue-List-Widget überblenden möchten, die Dauer der Cues wahrscheinlich mit dem [Speed ​​Dial-Widget](../speed-dial) auf „unendlich“ (∞) einstellen möchten). Dies kann im Chaser-Editor durch Klicken auf die Schaltfläche ![](/basics/speed.png) aktiviert werden.

--- a/pages/07.virtual-console/09.frame/default.v4_de.md
+++ b/pages/07.virtual-console/09.frame/default.v4_de.md
@@ -8,9 +8,9 @@ Ein Rahmen ist ein Container, der eine Vielzahl von Widgets, einschließlich and
 ## Konfiguration
 <hr>
 
-Rahmen können mit der Schaltfläche „Eigenschaften“ ![](/basics/edit.png) in der Symbolleiste oder durch Doppelklicken auf den Rahmen selbst konfiguriert werden.
+Rahmen können mit der Schaltfläche „Eigenschaften“ ![](/basics/edit.png) in der Symbolleiste oder durch Doppelklicken auf den Rahmen selbst konfiguriert werden.  
 
-Abgesehen von den standardmäßigen [Styling- und Platzierungsoptionen](../styling-and-placement) verfügen Rahmen über die folgenden zusätzlichen Optionen, die in zwei Registerkarten unterteilt sind:
+Abgesehen von den standardmäßigen [Styling- und Platzierungsoptionen](../styling-and-placement) verfügen Rahmen über die folgenden zusätzlichen Optionen, die in zwei Registerkarten unterteilt sind:  
 
 ### Registerkarte „Darstellung“.
 
@@ -21,8 +21,8 @@ Abgesehen von den standardmäßigen [Styling- und Platzierungsoptionen](../styli
 
 ### Registerkarte „Seiten“.
 
-Virtuelle Konsolenrahmen können in mehrseitige Widgets umgewandelt werden, was nützlich ist, wenn es um viele Widgets oder Controller geht, die Seiten unterstützen.
-Die Mehrseitenfunktion ist standardmäßig deaktiviert, kann aber auf dieser Registerkarte aktiviert werden.
+Virtuelle Konsolenrahmen können in mehrseitige Widgets umgewandelt werden, was nützlich ist, wenn es um viele Widgets oder Controller geht, die Seiten unterstützen.  
+Die Mehrseitenfunktion ist standardmäßig deaktiviert, kann aber auf dieser Registerkarte aktiviert werden.  
 Befolgen Sie die Optionen zum Konfigurieren dieser Funktionalität:
 
 * **Aktivieren**: Dieses Kontrollkästchen aktiviert/deaktiviert die Mehrseitenfunktionalität. Wenn diese Option aktiviert ist, zeigen VC-Frames zusätzliche Steuerelemente in der Kopfzeile an (sofern die Kopfzeile ebenfalls aktiviert ist). Dies sind: Schaltfläche „Vorherige Seite“, Seitenname und Schaltfläche „Nächste Seite“.
@@ -30,7 +30,7 @@ Befolgen Sie die Optionen zum Konfigurieren dieser Funktionalität:
 * **Widgets der ersten Seite klonen**: Wenn diese Option aktiviert ist, klont QLC+ die Widgets der ersten Seite des Frames in alle anderen neuen Seiten, die im Feld „Anzahl der Seiten“ definiert sind. Dies ist eine sehr nützliche Option, um die Zuordnung eines externen Controllers zu beschleunigen, bei dem alle Seiten über dieselben Widgets verfügen.
 * **Externer Eingang – Vorherige Seite**: Hier können Sie ein externes Eingangssignal oder eine Tastaturkombination einstellen, die bewirkt, dass die vorherige Seite des Rahmens angezeigt wird.
 * **Externer Eingang – Nächste Seite**: Hier können Sie ein externes Eingangssignal oder eine Tastaturkombination einstellen, die bewirkt, dass die vorherige Seite des Rahmens angezeigt wird.
-* **Seitenverknüpfungen**: Im unteren Bereich der Registerkarte „Seiten“ können Sie jeder Seite einen benutzerdefinierten Namen, ein externes Eingangssignal oder eine Tastaturkombination zuweisen.
+* **Seitenverknüpfungen**: Im unteren Bereich der Registerkarte „Seiten“ können Sie jeder Seite einen benutzerdefinierten Namen, ein externes Eingangssignal oder eine Tastaturkombination zuweisen.  
     Auf diese Weise kann direkt auf eine Seite zugegriffen werden, ohne dass die Zwischenseiten durchlaufen werden müssen.
 
 
@@ -41,6 +41,6 @@ Standardmäßig wird ein Frame mit einer Kopfzeile angezeigt. Im Folgenden finde
 
 * ![](/basics/expand.png) **Schaltfläche „Erweitern/Reduzieren“**: Wenn Sie darauf klicken, wird die Framegröße drastisch reduziert, um Platz auf Ihrer virtuellen Konsole zu sparen. Der reduzierte Zustand wird in Ihrem Projekt gespeichert.
 * **Frame-Name**: eine Beschriftung, die den Frame-Namen anzeigt
-* ![](/basics/check.png) **Schaltfläche „Aktivieren/Deaktivieren“**: Wenn Sie darauf klicken, wechselt der Frame in einen deaktivierten Zustand. Alle Widgets innerhalb des Frames reagieren nicht mehr auf Eingabesteuerelemente.
+* ![](/basics/check.png) **Schaltfläche „Aktivieren/Deaktivieren“**: Wenn Sie darauf klicken, wechselt der Frame in einen deaktivierten Zustand. Alle Widgets innerhalb des Frames reagieren nicht mehr auf Eingabesteuerelemente.  
     Dies ist beispielsweise nützlich, um dieselben Eingabesteuerelemente für Widgets verschiedener Frames zu verwenden. Wenn Sie beispielsweise die Taste „G“ an eine Schaltfläche in Frame A und auch an eine Schaltfläche in Frame B gebunden haben, können Sie jeweils einen Frame aktivieren, um Ihre Tastenbindung universell zu verwenden.
 * ![](/basics/back.png) Seite ![](/basics/forward.png) **Mehrseitige Steuerelemente** (Optional): Wenn ein Frame im Mehrseitenmodus konfiguriert ist, werden einige zusätzliche Schaltflächen angezeigt In der Kopfzeile können Sie zwischen den Frame-Seiten wechseln und den Überblick über die aktuelle Seite behalten, auf der Sie sich befinden.

--- a/pages/07.virtual-console/10.solo-frame/default.v4_de.md
+++ b/pages/07.virtual-console/10.solo-frame/default.v4_de.md
@@ -7,15 +7,15 @@ Ein Einzelrahmen ist fast genau die gleiche Art von Container wie ein normaler [
 
 ### Konfiguration
 
-Einzelrahmen können mit der Schaltfläche „Eigenschaften“ ![](/basics/edit.png) in der Symbolleiste oder durch Doppelklicken auf den Solo-Frame selbst konfiguriert werden.
+Einzelrahmen können mit der Schaltfläche „Eigenschaften“ ![](/basics/edit.png) in der Symbolleiste oder durch Doppelklicken auf den Solo-Frame selbst konfiguriert werden.  
 
-Abgesehen von den Standard-[Styling- und Platzierungsoptionen](../styling-and-placement) verfügen Einzelrahmen über alle [Frame](../frame)-Zusatzoptionen:
+Abgesehen von den Standard-[Styling- und Platzierungsoptionen](../styling-and-placement) verfügen Einzelrahmen über alle [Frame](../frame)-Zusatzoptionen:  
 
 * **Frame-Name**: Ermöglicht Ihnen, dem Einzelrahmen eine beliebige Bezeichnung zuzuweisen. Dies wird nur angezeigt, wenn die Option „Kopfzeile anzeigen“ aktiviert ist (siehe unten).
 * **Untergeordnete Widgets akzeptieren**: Ermöglicht das Hinzufügen von Widgets zum Einzelrahmen.
 * **Größenänderung zulassen**: Ermöglicht die Änderung der Höhe und Breite des Einzelrahmen.
 * **Kopfzeile anzeigen**: Zeigt eine nützliche Kopfzeile an, die aus einer Schaltfläche und einer Beschriftung besteht. Mit der Schaltfläche können Sie den Solo-Rahmen erweitern/reduzieren, wodurch viel Platz in der virtuellen Konsole gespart werden kann. Auf der Beschriftung wird der Name des Frames angezeigt.
 
-Und noch eine spezielle Option:
+Und noch eine spezielle Option:  
 
 * **Mix-Schieberegler im Wiedergabemodus**: Wenn diese Option aktiviert ist, dürfen die [Schieberegler](../slider) im **Wiedergabemodus** gleichzeitig aktiviert werden. Wenn Sie einen Schieberegler nach oben bewegen, werden die anderen laufenden Schieberegler nicht sofort abgebrochen, sondern mit der gleichen Geschwindigkeit ausgeblendet, mit der Sie ihn nach oben bewegen.

--- a/pages/07.virtual-console/12.audio-triggers/default.v4_de.md
+++ b/pages/07.virtual-console/12.audio-triggers/default.v4_de.md
@@ -3,21 +3,21 @@ title: 'Audio-Trigger'
 date: '03:46 22-08-2023'
 ---
 
-Ab QLC+ Version 4.4.0 können Sie mit dieser Funktionalität eine Audioeingangsquelle wie ein Mikrofon verwenden, um Ihren Lichtshows mehr Leben zu verleihen.
+Ab QLC+ Version 4.4.0 können Sie mit dieser Funktionalität eine Audioeingangsquelle wie ein Mikrofon verwenden, um Ihren Lichtshows mehr Leben zu verleihen.  
 
 Einführung
 ------------
 
-Wenn Sie auf das Symbol ![](/basics/audioinput.png) klicken, wird Ihrer virtuellen Konsole ein Audio-Trigger-Widget hinzugefügt.
-Der Grafikbereich des Widgets zeigt die Live-Überwachung des aufgenommenen Audios und zeigt eine Reihe von Spektrumbalken und einen Lautstärkebalken an.
-Unten sehen Sie den von QLC+ analysierten Frequenzbereich
+Wenn Sie auf das Symbol ![](/basics/audioinput.png) klicken, wird Ihrer virtuellen Konsole ein Audio-Trigger-Widget hinzugefügt.  
+Der Grafikbereich des Widgets zeigt die Live-Überwachung des aufgenommenen Audios und zeigt eine Reihe von Spektrumbalken und einen Lautstärkebalken an.  
+Unten sehen Sie den von QLC+ analysierten Frequenzbereich.  
 
 Konfiguration
 -------------
 
-Wenn Sie im Designmodus auf das Widget doppelklicken, wird ein Bedienfeld mit einem vollständigen Satz an Optionen zum Optimieren der Funktionalität des Audio-Triggers angezeigt.
-Als erstes können Sie die Anzahl der Spektrumbalken konfigurieren, die Sie anzeigen möchten und die Sie während Ihrer Live-Show benötigen. Die akzeptierte Zahl liegt zwischen 5 und 32.
-Sobald die Anzahl der Balken festgelegt ist, können Sie jedem Balken eine Funktionalität zuweisen. Es gibt eine Liste mit den folgenden Optionen für die Lautstärke- und Spektrumbalken:
+Wenn Sie im Designmodus auf das Widget doppelklicken, wird ein Bedienfeld mit einem vollständigen Satz an Optionen zum Optimieren der Funktionalität des Audio-Triggers angezeigt.  
+Als erstes können Sie die Anzahl der Spektrumbalken konfigurieren, die Sie anzeigen möchten und die Sie während Ihrer Live-Show benötigen. Die akzeptierte Zahl liegt zwischen 5 und 32.  
+Sobald die Anzahl der Balken festgelegt ist, können Sie jedem Balken eine Funktionalität zuweisen. Es gibt eine Liste mit den folgenden Optionen für die Lautstärke- und Spektrumbalken:  
 
 
 |     |     |

--- a/pages/08.input-output/01.input-profiles/default.v4_de.md
+++ b/pages/08.input-output/01.input-profiles/default.v4_de.md
@@ -48,8 +48,8 @@ Bisher besteht der einzige Unterschied darin, dass MIDI-Profile MIDI-Nachrichten
 #### Manueller Modus
 Wenn Sie sich mit MIDI-Codes gut auskennen oder die Plugins und ihre Funktionsweise gut kennen, können Sie die Parameter auch manuell eingeben.
 
-![](/basics/edit_add.png) Klicken Sie auf die Schaltfläche „Hinzufügen“, um individuelle Kanalinformationen für jeden Kanal manuell einzugeben.
-![](/basics/edit_remove.png) Klicken Sie hier, um einen vorhandenen Kanal zu entfernen
+![](/basics/edit_add.png) Klicken Sie auf die Schaltfläche „Hinzufügen“, um individuelle Kanalinformationen für jeden Kanal manuell einzugeben.  
+![](/basics/edit_remove.png) Klicken Sie hier, um einen vorhandenen Kanal zu entfernen.  
 
 #### Automatikmodus
 In den meisten Fällen ist es besser, die Tasten auf Ihrem Controller zu drücken, um sie automatisch zu erkennen und zuzuweisen.
@@ -62,7 +62,7 @@ Wenn Sie einen Kanal hinzufügen ![](/basics/edit_add.png) oder bearbeiten ![](/
 
 * **Nummer**: Die Kanalnummer. Da QLC+ eine Vielzahl von Eingabe-Plugins unterstützt, ist die Kanalnummer möglicherweise nicht intuitiv. Bearbeiten Sie sie daher nur, wenn Sie wissen, was Sie tun.
 * **Name**: Der Kanalname. Dies ist eine beliebige Zeichenfolge, die den Zweck eines Kanals angibt.
-* **Typ**: Der Kanaltyp. Dies kann sein: ![](/basics/slider.png) Slider, ![](/basics/knob.png) Knob, ![](/basics/button.png) Button oder ![](/basics/knob.png) Encoder
+* **Typ**: Der Kanaltyp. Dies kann sein: ![](/basics/slider.png) Slider, ![](/basics/knob.png) Knob, ![](/basics/button.png) Button oder ![](/basics/knob.png) Encoder.  
     Andere Typen: ![](/basics/back.png) Vorherige Seite, ![](/basics/forward.png) Nächste Seite, ![](/basics/star.png) Set Page werden zur Steuerung mehrseitiger Frames verwendet .
 
 Für MIDI-Profile enthält der Dialog zusätzliche Felder:
@@ -80,14 +80,14 @@ Hier können Sie die Kanalspezifikation (die in die Kanalnummer übersetzt wird)
 
 #### ![](/basics/slider.png) Bewegungseigenschaften der Schieberegler
 
-Wenn Ihr Eingabeprofil Schiebereglerkanäle enthält, werden beim Klicken darauf einige zusätzliche Eigenschaften unten im Hauptfenster des Eingabeprofil-Editors angezeigt. Damit können Sie festlegen, wie sich von einem Schieberegler empfangene Werte in QLC+ verhalten sollen.
+Wenn Ihr Eingabeprofil Schiebereglerkanäle enthält, werden beim Klicken darauf einige zusätzliche Eigenschaften unten im Hauptfenster des Eingabeprofil-Editors angezeigt. Damit können Sie festlegen, wie sich von einem Schieberegler empfangene Werte in QLC+ verhalten sollen.  
 
-Es gibt zwei Verhaltensweisen: Absolut und Relativ.
+Es gibt zwei Verhaltensweisen: Absolut und Relativ.  
 
-**Absolut** ist die Standardeinstellung und weist QLC+ grundsätzlich an, die Schiebereglerwerte genau so zu verwenden, wie sie von einem externen Controller empfangen werden.
+**Absolut** ist die Standardeinstellung und weist QLC+ grundsätzlich an, die Schiebereglerwerte genau so zu verwenden, wie sie von einem externen Controller empfangen werden.  
 
-**Relativ** ist ein erweitertes Verhalten, das nützlich ist, wenn ein HID-Joystick mit einem QLC+ [XY-Pad-Widget](/virtual-console/xy-pad) oder einem [Slider-Widget](/virtual-console/slider) verwendet wird. Von einem externen Controller empfangene Werte werden als relative Bewegung ausgehend von der aktuellen Position eines Widgets der virtuellen Konsole behandelt.
-Machen wir ein Beispiel. Angenommen, Sie haben ein XY-Pad in Ihrer virtuellen Konsole, das eine Gruppe beweglicher Köpfe steuert und überwacht. Während Ihrer Show werden Sie eine Reihe von Szenen sehen, in denen die Köpfe geschwenkt und geneigt werden. Irgendwann möchten Sie die Position der Köpfe geringfügig um einige Grad anpassen. Hier setzt die Relativbewegung ein. Wenn Sie Ihren Joystick (oder externen Schieberegler) bewegen, passt QLC+ die Köpfe von ihren aktuellen Positionen aus an. Die Richtung hängt direkt von Ihrem externen Controller ab. Die relative Bewegung stoppt, wenn der externe Controller zu seinem Ursprung zurückkehrt. Joysticks haben dafür eine Feder.
+**Relativ** ist ein erweitertes Verhalten, das nützlich ist, wenn ein HID-Joystick mit einem QLC+ [XY-Pad-Widget](/virtual-console/xy-pad) oder einem [Slider-Widget](/virtual-console/slider) verwendet wird. Von einem externen Controller empfangene Werte werden als relative Bewegung ausgehend von der aktuellen Position eines Widgets der virtuellen Konsole behandelt.  
+Machen wir ein Beispiel. Angenommen, Sie haben ein XY-Pad in Ihrer virtuellen Konsole, das eine Gruppe beweglicher Köpfe steuert und überwacht. Während Ihrer Show werden Sie eine Reihe von Szenen sehen, in denen die Köpfe geschwenkt und geneigt werden. Irgendwann möchten Sie die Position der Köpfe geringfügig um einige Grad anpassen. Hier setzt die Relativbewegung ein. Wenn Sie Ihren Joystick (oder externen Schieberegler) bewegen, passt QLC+ die Köpfe von ihren aktuellen Positionen aus an. Die Richtung hängt direkt von Ihrem externen Controller ab. Die relative Bewegung stoppt, wenn der externe Controller zu seinem Ursprung zurückkehrt. Joysticks haben dafür eine Feder.  
 Darüber hinaus können Sie mit der Einstellung „Input Profile Editor Relative“ einen **Empfindlichkeit**-Parameter festlegen, der QLC+ über die Stärke Ihrer externen Controller-Bewegungen informiert. Je höher dieser Wert ist, desto langsamer erfolgen die Bewegungen. Je niedriger, desto schneller.
 
 
@@ -98,15 +98,15 @@ Ein Encoder ist ein endloser Drehregler und kann nur als relativer Regler behand
 
 #### ![](/basics/button.png) Schaltflächeneigenschaften
 
-Es ist möglich, das Verhalten einzelner Schaltflächen über ein Eingabeprofil zu ändern, und die folgenden Eigenschaften werden global in QLC+ verwendet.
+Es ist möglich, das Verhalten einzelner Schaltflächen über ein Eingabeprofil zu ändern, und die folgenden Eigenschaften werden global in QLC+ verwendet.  
 
-**Beim Umschalten ein zusätzliches Drücken/Loslassen erzeugen**: Dies ist eine ganz spezielle Option, die beispielsweise beim Umgang mit TouchOSC oder dem Behringer BCF2000 verwendet wird.
-QLC+-Umschaltereignisse werden ausgelöst, wenn eine High+Low-Sequenz empfangen wird. Das bedeutet, dass QLC+ einen Wert ungleich Null (normalerweise 255) erwartet, gefolgt von einem Nullwert, um beispielsweise eine Schaltfläche umzuschalten.
-Geräte wie BCF2000 oder Software wie TouchOSC senden stattdessen beim Aktivieren einer Schaltfläche nur einen Wert ungleich Null und beim Deaktivieren einen Nullwert.
-Wenn diese Option aktiviert ist, generiert QLC+ die „fehlenden“ Ereignisse, um die Funktionsweise einiger Controller zu standardisieren. So sieht es beispielsweise so aus, als würde der BCF2000 beim Drücken einer Taste 255+0 senden und beim erneuten Drücken weitere 255+0.
+**Beim Umschalten ein zusätzliches Drücken/Loslassen erzeugen**: Dies ist eine ganz spezielle Option, die beispielsweise beim Umgang mit TouchOSC oder dem Behringer BCF2000 verwendet wird.  
+QLC+-Umschaltereignisse werden ausgelöst, wenn eine High+Low-Sequenz empfangen wird. Das bedeutet, dass QLC+ einen Wert ungleich Null (normalerweise 255) erwartet, gefolgt von einem Nullwert, um beispielsweise eine Schaltfläche umzuschalten.  
+Geräte wie BCF2000 oder Software wie TouchOSC senden stattdessen beim Aktivieren einer Schaltfläche nur einen Wert ungleich Null und beim Deaktivieren einen Nullwert.  
+Wenn diese Option aktiviert ist, generiert QLC+ die „fehlenden“ Ereignisse, um die Funktionsweise einiger Controller zu standardisieren. So sieht es beispielsweise so aus, als würde der BCF2000 beim Drücken einer Taste 255+0 senden und beim erneuten Drücken weitere 255+0.  
 
-**Benutzerdefiniertes Feedback**: Mit den Feldern „Unterer Wert“ und „Oberer Wert“ ist es möglich, das Senden benutzerdefinierter Werte zu erzwingen, wenn die ausgewählte Schaltfläche einen Wert ungleich Null und einen Wert von Null sendet.
-Mit dieser Option ist es beispielsweise möglich, global festzulegen, wie die LEDs von AKAI APC-Geräten gefärbt werden sollen, wenn sie aktiviert/deaktiviert werden.
+**Benutzerdefiniertes Feedback**: Mit den Feldern „Unterer Wert“ und „Oberer Wert“ ist es möglich, das Senden benutzerdefinierter Werte zu erzwingen, wenn die ausgewählte Schaltfläche einen Wert ungleich Null und einen Wert von Null sendet.  
+Mit dieser Option ist es beispielsweise möglich, global festzulegen, wie die LEDs von AKAI APC-Geräten gefärbt werden sollen, wenn sie aktiviert/deaktiviert werden.  
 Beachten Sie, dass diese Option in QLC+ global ist, aber bei Bedarf von einem bestimmten Widget der virtuellen Konsole über dessen Konfigurationsseite überschrieben werden kann.
 
 ### Farben
@@ -128,10 +128,10 @@ Einige Controller ermöglichen die Zuordnung verschiedener Kanäle zu unterschie
 
 # Zurück zum Eingabeprofil-Definitionsfenster
 
-Wenn Sie mit der Kanalzuordnung fertig sind, klicken Sie auf die Schaltfläche „OK“, um die Änderungen zu übernehmen und das Eingabeprofil zu speichern. Wenn Sie für das Profil keinen Hersteller/kein Modell eingegeben haben, werden Sie zur Eingabe aufgefordert, bevor Sie fortfahren können.
+Wenn Sie mit der Kanalzuordnung fertig sind, klicken Sie auf die Schaltfläche „OK“, um die Änderungen zu übernehmen und das Eingabeprofil zu speichern. Wenn Sie für das Profil keinen Hersteller/kein Modell eingegeben haben, werden Sie zur Eingabe aufgefordert, bevor Sie fortfahren können.  
 Jetzt sollten Sie das Profil, das Sie gerade definiert haben, in der Liste der verfügbaren Eingabeprofile sehen. Erinnern Sie sich, wie man es dem aktuellen Universum zuordnet? Scrollen Sie nach oben zu Profilzuordnung, wenn Sie dies nicht tun.
 
 Um vorhandene Eingabeprofile zu entfernen, klicken Sie auf die Schaltfläche ![](/basics/edit_remove.png) zum Entfernen. Beachten Sie, dass einige Profile sogenannte Systemprofile sind und nicht entfernt werden können, es sei denn, Sie sind der Administrator.
 
-Das ist alles!
+Das ist alles!  
 Jetzt können Sie Ihr bevorzugtes Profil verwenden. Wenn Sie einem QLC+-Element (wie Schiebereglern der virtuellen Konsole, Kanalgruppen usw.) einen Eingangskanal zuweisen, werden Sie sehen, dass Ihre Eingangsprofilzuordnung verwendet wird.

--- a/pages/08.input-output/02.audio/default.v4_de.md
+++ b/pages/08.input-output/02.audio/default.v4_de.md
@@ -5,14 +5,14 @@ date: '05:01 22-08-2023'
 
 Auf dieser Seite wird beschrieben, wie Sie ein Eingabe- oder Ausgabe-Audiogerät auswählen, das in QLC+ verwendet werden soll.
 
-Um auf den Eingabe-/Ausgabe-Manager zuzugreifen, klicken Sie einfach auf die Registerkarte mit dem Symbol ![](/basics/input_output.png) am unteren Rand des QLC+-Hauptbildschirms.
+Um auf den Eingabe-/Ausgabe-Manager zuzugreifen, klicken Sie einfach auf die Registerkarte mit dem Symbol ![](/basics/input_output.png) am unteren Rand des QLC+-Hauptbildschirms.  
 Wählen Sie auf der linken Seite des Bildschirms das gewünschte Universum aus und klicken Sie dann auf die Registerkarte „Audio“, die sich neben der Registerkarte „Profil“ oben rechts auf dem Bildschirm befindet.
 
-Die Liste der von QLC+ erkannten Audiogeräte wird angezeigt. Jedes Gerät verfügt über ein Kontrollkästchen, je nachdem, ob es Eingabeerfassungs- oder Audioausgabefunktionen unterstützt.
-Der erste Eintrag der Liste ist immer **„Standardgerät“** und wird standardmäßig als Ein- und Ausgang ausgewählt. Auf diese Weise funktioniert QLC+ in den meisten Fällen sofort.
-Das Standardgerät ist das Gerät, mit dem Sie derzeit Musik hören oder Audio mit einem Mikrofon aufnehmen.
+Die Liste der von QLC+ erkannten Audiogeräte wird angezeigt. Jedes Gerät verfügt über ein Kontrollkästchen, je nachdem, ob es Eingabeerfassungs- oder Audioausgabefunktionen unterstützt.  
+Der erste Eintrag der Liste ist immer **„Standardgerät“** und wird standardmäßig als Ein- und Ausgang ausgewählt. Auf diese Weise funktioniert QLC+ in den meisten Fällen sofort.  
+Das Standardgerät ist das Gerät, mit dem Sie derzeit Musik hören oder Audio mit einem Mikrofon aufnehmen.  
 
-Wenn in Ihrem System zusätzliche Audiokarten (PCI oder USB) vorhanden sind, können Sie diese in diesem Bereich als bevorzugtes QLC+-Eingabe- oder Ausgabegerät auswählen.
-Grundsätzlich wird ein Eingabegerät von [Audio-Triggern der virtuellen Konsole](/virtual-console/audio-triggers) verwendet, während ein Ausgabegerät von [Audiofunktionen](/basics/glossary-and-concepts#audio) verwendet wird.
+Wenn in Ihrem System zusätzliche Audiokarten (PCI oder USB) vorhanden sind, können Sie diese in diesem Bereich als bevorzugtes QLC+-Eingabe- oder Ausgabegerät auswählen.  
+Grundsätzlich wird ein Eingabegerät von [Audio-Triggern der virtuellen Konsole](/virtual-console/audio-triggers) verwendet, während ein Ausgabegerät von [Audiofunktionen](/basics/glossary-and-concepts#audio) verwendet wird.  
 
 Die Auswahl einer Audio-Eingangs-/Ausgangsleitung sollte in QLC+ sofort wirksam werden. Wenn nicht, werden Sie aufgefordert, QLC+ neu zu starten, um eine vollständige Initialisierung der internen Audio-Engine zu ermöglichen.

--- a/pages/08.input-output/chapter.v4_de.md
+++ b/pages/08.input-output/chapter.v4_de.md
@@ -14,30 +14,30 @@ taxonomy:
 
 # Eingabe/Ausgabe
 
-Standardmäßig bietet QLC+ 4 Universen, Sie können diese jedoch nach Bedarf hinzufügen/entfernen.
-Die Eingabe-/Ausgabezuordnung wird im aktuell geladenen Projekt gespeichert. Dadurch können Sie Ihr Projekt auf einen anderen Computer/Betriebssystem portieren, ohne es jedes Mal neu konfigurieren zu müssen.
+Standardmäßig bietet QLC+ 4 Universen, Sie können diese jedoch nach Bedarf hinzufügen/entfernen.  
+Die Eingabe-/Ausgabezuordnung wird im aktuell geladenen Projekt gespeichert. Dadurch können Sie Ihr Projekt auf einen anderen Computer/Betriebssystem portieren, ohne es jedes Mal neu konfigurieren zu müssen.  
 Wenn kein Projekt geladen ist, behält QLC+ die I/O-Zuordnung als „Fallback“-Konfiguration bei.
 
 Eingabe-/Ausgabemanager
 --------------------
 
-Um auf den Eingabe-/Ausgabe-Manager zuzugreifen, klicken Sie einfach auf die Registerkarte mit dem Symbol ![](/basics/input_output.png) am unteren Rand des QLC+-Hauptbildschirms.
-Der Bildschirm ist folgendermaßen aufgebaut:
+Um auf den Eingabe-/Ausgabe-Manager zuzugreifen, klicken Sie einfach auf die Registerkarte mit dem Symbol ![](/basics/input_output.png) am unteren Rand des QLC+-Hauptbildschirms.  
+Der Bildschirm ist folgendermaßen aufgebaut:  
 
 * Auf der linken Seite befindet sich die Liste der internen Universen, die QLC+ verwalten kann
 * Auf der rechten Seite befindet sich die Liste der Geräte und ihrer zugeordneten Eingänge, Ausgänge und Rückkopplungsleitungen, die QLC+ erkannt hat
 * Unten rechts befindet sich ein Bereich mit kurzen Informationen zum aktuell ausgewählten Gerät
 
-Jedes Gerät verfügt über ein Kontrollkästchen, wenn eine Eingangs-, Ausgangs- oder Rückmeldeleitung verfügbar ist.
-Jedes QLC+-Universum kann einen einzelnen Eingang, einen einzelnen Ausgang und eine einzelne Feedback-Leitung abbilden
+Jedes Gerät verfügt über ein Kontrollkästchen, wenn eine Eingangs-, Ausgangs- oder Rückmeldeleitung verfügbar ist.  
+Jedes QLC+-Universum kann einen einzelnen Eingang, einen einzelnen Ausgang und eine einzelne Feedback-Leitung abbilden.  
 
-Einige Plugins müssen möglicherweise konfiguriert werden, bevor sie verwendet werden können, sodass Sie zunächst möglicherweise nicht alle Ein-/Ausgaben sehen können. Die Konfigurationsschaltfläche befindet sich neben dem Informationsfeld und ist aktiviert, wenn das Plugin manuelle Einstellungen zulässt.
+Einige Plugins müssen möglicherweise konfiguriert werden, bevor sie verwendet werden können, sodass Sie zunächst möglicherweise nicht alle Ein-/Ausgaben sehen können. Die Konfigurationsschaltfläche befindet sich neben dem Informationsfeld und ist aktiviert, wenn das Plugin manuelle Einstellungen zulässt.  
 Das Schaltflächensymbol ist: ![](/basics/configure.png)
 
 Universen hinzufügen/entfernen
 -------------------------
 
-QLC+ unterstützt eine beliebige Anzahl von Universen, abhängig vom CPU-Limit des Geräts, das sie steuert.
+QLC+ unterstützt eine beliebige Anzahl von Universen, abhängig vom CPU-Limit des Geräts, das sie steuert.  
 Auf der linken Seite des Input/Output Managers befindet sich eine Symbolleiste, in der Sie Universen hinzufügen/entfernen, benennen und konfigurieren können.
 
 |     |     |
@@ -50,10 +50,10 @@ Auf der linken Seite des Input/Output Managers befindet sich eine Symbolleiste, 
 Patchen
 --------
 
-Um die Eingabe-/Ausgabezeile eines Plugins auf das ausgewählte Universum zu patchen, müssen Sie ein Häkchen in der Eingabe-/Ausgabezeile dieses bestimmten Plugins setzen. Sie können einem Universum jeweils nur eine Zeile zuweisen. Wenn Sie also eine andere Zeile markieren, verschiebt sich das Häkchen von seiner vorherigen Position zu der gerade markierten Position.
+Um die Eingabe-/Ausgabezeile eines Plugins auf das ausgewählte Universum zu patchen, müssen Sie ein Häkchen in der Eingabe-/Ausgabezeile dieses bestimmten Plugins setzen. Sie können einem Universum jeweils nur eine Zeile zuweisen. Wenn Sie also eine andere Zeile markieren, verschiebt sich das Häkchen von seiner vorherigen Position zu der gerade markierten Position.  
 Wenn Sie bei einem Plugin keine Zeile sehen, bedeutet das, dass Sie kein Gerät haben, das QLC+ versteht, und Ihnen die einzige (nicht auswählbare) Wahl bleibt: Keine.
 
-Wenn eine Eingabe-/Ausgabezeile aktiviert wird, ändern sich die entsprechenden Universumsinformationen auf der linken Seite des Bildschirms und der neue Konfigurationssatz wird angezeigt.
+Wenn eine Eingabe-/Ausgabezeile aktiviert wird, ändern sich die entsprechenden Universumsinformationen auf der linken Seite des Bildschirms und der neue Konfigurationssatz wird angezeigt.  
 Die Plugin-Informationen unten rechts auf dem Bildschirm ändern sich ebenfalls und geben Ihnen den neuen Status der Plugin-Zeile an.
 
 Universum-Passthrough
@@ -71,10 +71,10 @@ Passthrough-Daten werden von QLC+-Grandmaster- oder Kanalmodifikatoren nicht bee
 Input und Feedback
 -------------------
 
-Wenn eine Plugin-Eingangszeile überprüft wird, wird sie sofort aktiviert, sodass Sie einen einfachen Test durchführen können, um noch einmal zu überprüfen, ob Ihre Hardware ordnungsgemäß mit QLC+ funktioniert.
+Wenn eine Plugin-Eingangszeile überprüft wird, wird sie sofort aktiviert, sodass Sie einen einfachen Test durchführen können, um noch einmal zu überprüfen, ob Ihre Hardware ordnungsgemäß mit QLC+ funktioniert.  
 Bewegen Sie einfach einen Fader/Regler an Ihrem externen Gerät, und wenn alles gut funktioniert, wird auf der linken Seite des Bildschirms neben dem entsprechenden Universum ein ![](/basics/input.png)-Symbol angezeigt.
 
-Wenn Ihr Eingabegerät einen Rückkanal unterstützt, kann QLC+ eine visuelle/mechanische Rückmeldung an ihn senden. Geräte wie Behringer BCF2000 unterstützen diese Funktion.
+Wenn Ihr Eingabegerät einen Rückkanal unterstützt, kann QLC+ eine visuelle/mechanische Rückmeldung an ihn senden. Geräte wie Behringer BCF2000 unterstützen diese Funktion.  
 Derzeit wird Feedback nur über MIDI, OSC und Loopback unterstützt.
 
 Um zu erfahren, wie Sie Ihr externes Eingabegerät für die optimale Verwendung mit QLC+ einrichten, lesen Sie bitte weiter mit der [Anleitung für Eingabeprofile](input-profiles).

--- a/pages/09.plugins/01.art-net/default.v4_de.md
+++ b/pages/09.plugins/01.art-net/default.v4_de.md
@@ -6,54 +6,54 @@ date: '05:06 22-08-2023'
 Einführung
 ------------
 
-QLC+ unterstützt das [Art-Net-Protokoll](https://en.wikipedia.org/wiki/Art-Net) über ein Eingabe-/Ausgabe-Plugin, das Pakete im Netzwerk empfängt und überträgt.
-Es sind keine zusätzlichen Anforderungen erforderlich, da QLC+ über eine native Implementierung des Art-Net-Protokolls verfügt, das auf Linux-, Windows- und macOS-Systemen funktioniert.
-Das Art-Net-Plugin kann Pakete von mehreren Netzwerkkarten, virtuellen Adressen, dem Loopback-Gerät (127.0.0.1) und mehreren Universen pro Netzwerkschnittstelle senden und empfangen.
-Standardmäßig werden Art-Net-Pakete als UDP übertragen, wobei der Standardport 6454 und die Broadcast-Adresse der ausgewählten Schnittstelle (z. B. 192.168.0.255) verwendet werden. Bei Verwendung des Loopback-Geräts werden Pakete immer über die Adresse 127.0.0.1 übertragen.
-Bei der Übertragung mehrerer Universen über dieselbe Schnittstelle werden die Pakete standardmäßig mit einer Art-Net-Universum-ID gesendet, die der QLC+-Universumsnummer minus 1 entspricht.
+QLC+ unterstützt das [Art-Net-Protokoll](https://en.wikipedia.org/wiki/Art-Net) über ein Eingabe-/Ausgabe-Plugin, das Pakete im Netzwerk empfängt und überträgt.  
+Es sind keine zusätzlichen Anforderungen erforderlich, da QLC+ über eine native Implementierung des Art-Net-Protokolls verfügt, das auf Linux-, Windows- und macOS-Systemen funktioniert.  
+Das Art-Net-Plugin kann Pakete von mehreren Netzwerkkarten, virtuellen Adressen, dem Loopback-Gerät (127.0.0.1) und mehreren Universen pro Netzwerkschnittstelle senden und empfangen.  
+Standardmäßig werden Art-Net-Pakete als UDP übertragen, wobei der Standardport 6454 und die Broadcast-Adresse der ausgewählten Schnittstelle (z. B. 192.168.0.255) verwendet werden. Bei Verwendung des Loopback-Geräts werden Pakete immer über die Adresse 127.0.0.1 übertragen.  
+Bei der Übertragung mehrerer Universen über dieselbe Schnittstelle werden die Pakete standardmäßig mit einer Art-Net-Universum-ID gesendet, die der QLC+-Universumsnummer minus 1 entspricht.  
 
-Zum Beispiel:
-QLC+ Universum 1 -> Art-Net Universum 0
-QLC+ Universum 2 -> Art-Net Universum 1
-...
-QLC+ Universum 8 -> Art-Net Universum 7
+Zum Beispiel:  
+QLC+ Universum 1 -> Art-Net Universum 0  
+QLC+ Universum 2 -> Art-Net Universum 1  
+...  
+QLC+ Universum 8 -> Art-Net Universum 7  
 
-Diese Wahl ist auf einige Fakten zurückzuführen:
-1- Das erste gültige Art-Net-Universum ist 0 und nicht 1
-2- Das erste von kommerziellen Art-Net-DMX-Geräten wie eDMX und ODE akzeptierte Universum ist 0. Damit QLC+ sofort funktioniert, muss das erste Art-Net-Universum 0 sein.
+Diese Wahl ist auf einige Fakten zurückzuführen:  
+1- Das erste gültige Art-Net-Universum ist 0 und nicht 1  
+2- Das erste von kommerziellen Art-Net-DMX-Geräten wie eDMX und ODE akzeptierte Universum ist 0. Damit QLC+ sofort funktioniert, muss das erste Art-Net-Universum 0 sein.  
 
 Sollten die oben genannten Einstellungen nicht den Anforderungen Ihres Netzwerks entsprechen, lesen Sie bitte das folgende Kapitel.
 
 Konfiguration
 -------------
 
-Wenn Sie auf die Konfigurationsschaltfläche ![](/basics/configure.png) klicken, wird ein kleiner Dialog mit zwei Registerkarten angezeigt: die Universe-Konfiguration und der Knotenbaum.
+Wenn Sie auf die Konfigurationsschaltfläche ![](/basics/configure.png) klicken, wird ein kleiner Dialog mit zwei Registerkarten angezeigt: die Universe-Konfiguration und der Knotenbaum.  
 
-**Universenkonfiguration**: Nachdem ein QLC+-Universum mit einem Art-Net-Ein- oder -Ausgang gepatcht wurde, wird in dieser Liste ein Eintrag angezeigt, der es ermöglicht, die gewünschten Parameter, die vom Art-Net-Plugin verwendet werden sollen, manuell zu konfigurieren.
-Eingabezeilen haben keine besonderen Parameter, während eine Ausgabezeile wie folgt konfiguriert werden kann:
+**Universenkonfiguration**: Nachdem ein QLC+-Universum mit einem Art-Net-Ein- oder -Ausgang gepatcht wurde, wird in dieser Liste ein Eintrag angezeigt, der es ermöglicht, die gewünschten Parameter, die vom Art-Net-Plugin verwendet werden sollen, manuell zu konfigurieren.  
+Eingabezeilen haben keine besonderen Parameter, während eine Ausgabezeile wie folgt konfiguriert werden kann:  
 
-* **IP-Adresse**: Dies ist die Ziel-IP-Adresse, an die das Art-Net-Plugin Pakete überträgt. Standardmäßig wird eine Broadcast-Adresse verwendet (die also mit .255 endet). Wenn Sie diese im Bereich von 1 bis 254 festlegen, überträgt Art-Net ein QLC+-Universum im Unicast-Modus. Wenn Ihr Art-Net-Netzwerk einen einfachen Hub verwendet, ist die ausgegebene IP-Adresse irrelevant, da Broadcast oder Unicast keinen Unterschied machen. Wenn Sie jedoch einen Netzwerk-Switch verwenden, ist Unicast von grundlegender Bedeutung, um die Netzwerküberlastung auszugleichen, da jeder Port des Switches einer Netzwerk-IP zugeordnet ist und nur die Pakete mit seiner Ziel-IP empfängt.
+* **IP-Adresse**: Dies ist die Ziel-IP-Adresse, an die das Art-Net-Plugin Pakete überträgt. Standardmäßig wird eine Broadcast-Adresse verwendet (die also mit .255 endet). Wenn Sie diese im Bereich von 1 bis 254 festlegen, überträgt Art-Net ein QLC+-Universum im Unicast-Modus. Wenn Ihr Art-Net-Netzwerk einen einfachen Hub verwendet, ist die ausgegebene IP-Adresse irrelevant, da Broadcast oder Unicast keinen Unterschied machen. Wenn Sie jedoch einen Netzwerk-Switch verwenden, ist Unicast von grundlegender Bedeutung, um die Netzwerküberlastung auszugleichen, da jeder Port des Switches einer Netzwerk-IP zugeordnet ist und nur die Pakete mit seiner Ziel-IP empfängt.  
     **Hinweis**: Stellen Sie die Ausgangs-IP-Adresse nicht auf dieselbe IP-Adresse Ihres sendenden Knotens (z. B. des PCs, auf dem QLC+ läuft) ein, da dies einfach falsch ist und eine Netzwerkschleife verursachen kann. Wenn Sie mit einem Art-Net-Knoten kommunizieren müssen, der auf demselben Computer läuft, auf dem QLC+ läuft, verwenden Sie stattdessen das Loopback-Gerät (127.0.0.1).
 * **Art-Net-Universum**: Dies ist das Art-Net-Universum, das tatsächlich in jedes übertragene Paket geschrieben wird. Durch Einstellen dieses Parameters können Sie jedes QLC+-Universum zur Übertragung an das gewünschte Art-Net-Universum verwenden.
-* **Übertragungsmodus**: Hier können Sie auswählen, ob QLC+ vollständige oder teilweise Universen übertragen soll.
-    _Standard_ bedeutet, dass DMX-Universen nur übertragen werden, wenn sich mindestens ein DMX-Kanal ändert oder alle 2 Sekunden, um die Werte des Empfängers zu aktualisieren.
-    _Vollständig_ bedeutet, dass alle 512 DMX-Kanäle eines Universums mit der Geschwindigkeit des internen QLC+-Takts (50 Hz) übertragen werden, was eine feste Bitrate von etwa 250 kbps ergibt.
+* **Übertragungsmodus**: Hier können Sie auswählen, ob QLC+ vollständige oder teilweise Universen übertragen soll.  
+    _Standard_ bedeutet, dass DMX-Universen nur übertragen werden, wenn sich mindestens ein DMX-Kanal ändert oder alle 2 Sekunden, um die Werte des Empfängers zu aktualisieren.  
+    _Vollständig_ bedeutet, dass alle 512 DMX-Kanäle eines Universums mit der Geschwindigkeit des internen QLC+-Takts (50 Hz) übertragen werden, was eine feste Bitrate von etwa 250 kbps ergibt.  
     _Teilweise_ bedeutet stattdessen, dass QLC+ nur den tatsächlich in einem Universum verwendeten DMX-Kanal überträgt, beginnend mit Kanal 1. Wenn Sie beispielsweise Kanal 3 eines Geräts mit der Adresse 50 erhöhen, überträgt das Art-Net-Plugin nur 53 DMX-Kanäle. Dadurch wird die Übertragungsbitrate begrenzt. Verwenden Sie diese Einstellung nur, wenn der empfangende Art-Net-Knoten eine teilweise Übertragung unterstützt.
 
-Einstellungen, die von den Plugin-Standardeinstellungen abweichen, werden in Ihrem QLC+-Arbeitsbereich gespeichert, um die Portabilität eines Projekts über verschiedene Plattformen hinweg zu erhöhen, z. B. verschiedene Betriebssysteme oder einen PC und einen Raspberry Pi.
+Einstellungen, die von den Plugin-Standardeinstellungen abweichen, werden in Ihrem QLC+-Arbeitsbereich gespeichert, um die Portabilität eines Projekts über verschiedene Plattformen hinweg zu erhöhen, z. B. verschiedene Betriebssysteme oder einen PC und einen Raspberry Pi.  
 
 **Knotenbaum**: Auf dieser Registerkarte werden die im Netzwerk erkannten Art-Net-Knoten angezeigt, gruppiert nach Netzwerkschnittstelle.
-QLC+ wird in dieser Liste immer als am Netzwerk teilnehmender Knoten angezeigt.
+QLC+ wird in dieser Liste immer als am Netzwerk teilnehmender Knoten angezeigt.  
 Art-Net-Knoten werden dieser Liste hinzugefügt, wenn sie die ArtPoll/ArtPollReply-Nachricht unterstützen, andernfalls werden sie nicht angezeigt. Das bedeutet nicht, dass Sie nicht mit ihnen kommunizieren können.
 
 DMXKing eDMX und ENTTEC ODE
 ---------------------------
 
-Wenn Sie eines dieser Geräte besitzen, verfügen beide über Konfigurationstools, die bei der Arbeit mit QLC+ nützlich sein können. Mit ihnen können Sie mehrere Parameter einstellen, um die beste Konfiguration für die Eingabe/Ausgabe von Daten von/an QLC+ zu finden.
-Wenn Sie beispielsweise möchten, dass das QLC+-Universum 3 Daten auf dem ersten Port eines eDMX ausgibt, müssen Sie das folgende Tool verwenden, um die Adresse des Geräteuniversums in 2 zu ändern.
+Wenn Sie eines dieser Geräte besitzen, verfügen beide über Konfigurationstools, die bei der Arbeit mit QLC+ nützlich sein können. Mit ihnen können Sie mehrere Parameter einstellen, um die beste Konfiguration für die Eingabe/Ausgabe von Daten von/an QLC+ zu finden.  
+Wenn Sie beispielsweise möchten, dass das QLC+-Universum 3 Daten auf dem ersten Port eines eDMX ausgibt, müssen Sie das folgende Tool verwenden, um die Adresse des Geräteuniversums in 2 zu ändern.  
 
-Hier die Links zum Herunterladen der Tools:
-[DMXKing eDMX-Konfigurationstool](https://dmxking.com/downloads/eDMX_Configuration.zip)
+Hier die Links zum Herunterladen der Tools:  
+[DMXKing eDMX-Konfigurationstool](https://dmxking.com/downloads/eDMX_Configuration.zip)  
 [ENTTEC-Knotenverwaltungsdienstprogramm](https://www.enttec.com/?main_menu=Products&pn=79001)
 
 Kompatibilität

--- a/pages/09.plugins/02.dmx-usb/default.v4.md
+++ b/pages/09.plugins/02.dmx-usb/default.v4.md
@@ -44,14 +44,14 @@ sudo adduser your\_user\_name dialout
 
 ### macOS
 
-On Apple macOS, you don't need any drivers at all since QLC+ uses the macOS native USB interface. Installing the D2XX drivers should cause no harm, but **DO NOT INSTALL VCP (Virtual COM Port) drivers** as they will definitely interfere with QLC+. If you have previously installed the VCP drivers, consult the [FTDI installation guides](https://ftdichip.com/document/installation-guides/) on how to uninstall them.
+On Apple macOS, you don't need any drivers at all since QLC+ uses the macOS native USB interface. Installing the D2XX drivers should cause no harm, but **DO NOT INSTALL VCP (Virtual COM Port) drivers** as they will definitely interfere with QLC+. If you have previously installed the VCP drivers, consult the [FTDI installation guides](https://ftdichip.com/document/installation-guides/) on how to uninstall them.  
   
 **OSX Mavericks (or later) issues**: please check [Questions & answers #3](/basics/questions-and-answers)
 
 ### Windows
 
-On Microsoft Windows, the plugin needs the [latest D2XX drivers from FTDI](https://ftdichip.com/drivers/d2xx-drivers/). Normally, when a FTDI device is plugged in for the first time, Windows will automatically download the D2XX drivers for you, so no action is needed at all.
-If that doesn't happen, please consult the [FTDI installation guides](https://ftdichip.com/document/installation-guides/) to know how to install the drivers.
+On Microsoft Windows, the plugin needs the [latest D2XX drivers from FTDI](https://ftdichip.com/drivers/d2xx-drivers/). Normally, when a FTDI device is plugged in for the first time, Windows will automatically download the D2XX drivers for you, so no action is needed at all.  
+If that doesn't happen, please consult the [FTDI installation guides](https://ftdichip.com/document/installation-guides/) to know how to install the drivers.  
 **DO NOT INSTALL VCP (Virtual COM Port) drivers** as they will probably interfere with the D2XX interface.
 
 ENTTEC DMX USB Pro supported modes

--- a/pages/09.plugins/02.dmx-usb/default.v4_ca.md
+++ b/pages/09.plugins/02.dmx-usb/default.v4_ca.md
@@ -50,9 +50,9 @@ A l'Apple macOS, no necessites cap controlador, ja que QLC+ utilitza la interfí
 
 ### Windows
 
-A Microsoft Windows, el connector necessita els [últims controladors D2XX de FTDI](https://ftdichip.com/drivers/d2xx-drivers/). Normalment, quan un dispositiu FTDI està connectat per primera vegada, Windows us baixarà automàticament els controladors D2XX, de manera que no cal cap acció.
+A Microsoft Windows, el connector necessita els [últims controladors D2XX de FTDI](https://ftdichip.com/drivers/d2xx-drivers/). Normalment, quan un dispositiu FTDI està connectat per primera vegada, Windows us baixarà automàticament els controladors D2XX, de manera que no cal cap acció.  
 Si això no passa, consulteu les [guies d'instal·lació FTDI](https://ftdichip.com/document/installation-guides/) per saber com instal·lar els controladors.
-**NO INSTAL·LEU controladors VCP (Port Virtual COM)**, ja que probablement interferiran amb la interfície D2XX.
+**NO INSTAL·LEU controladors VCP (Port Virtual COM)**, ja que probablement interferiran amb la interfície D2XX.  
 
 Modes compatibles amb ENTTEC DMX USB Pro
 ----------------------------------

--- a/pages/09.plugins/02.dmx-usb/default.v4_de.md
+++ b/pages/09.plugins/02.dmx-usb/default.v4_de.md
@@ -44,14 +44,14 @@ sudo adduser your\_user\_name dialout
 
 ### macOS
 
-Unter Apple macOS benötigen Sie überhaupt keine Treiber, da QLC+ die native USB-Schnittstelle von macOS verwendet. Die Installation der D2XX-Treiber sollte keinen Schaden anrichten, aber **INSTALLIEREN SIE KEINE VCP-Treiber (Virtual COM Port)**, da diese definitiv QLC+ beeinträchtigen. Wenn Sie die VCP-Treiber zuvor installiert haben, lesen Sie in den [FTDI-Installationshandbüchern](https://ftdichip.com/document/installation-guides/) nach, wie Sie sie deinstallieren.
+Unter Apple macOS benötigen Sie überhaupt keine Treiber, da QLC+ die native USB-Schnittstelle von macOS verwendet. Die Installation der D2XX-Treiber sollte keinen Schaden anrichten, aber **INSTALLIEREN SIE KEINE VCP-Treiber (Virtual COM Port)**, da diese definitiv QLC+ beeinträchtigen. Wenn Sie die VCP-Treiber zuvor installiert haben, lesen Sie in den [FTDI-Installationshandbüchern](https://ftdichip.com/document/installation-guides/) nach, wie Sie sie deinstallieren.  
 
 **Probleme mit OSX Mavericks (oder höher)**: Bitte überprüfen Sie [Fragen und Antworten Nr. 3](/basics/questions-and-answers)
 
 ### Windows
 
-Unter Microsoft Windows benötigt das Plugin die [neuesten D2XX-Treiber von FTDI](https://ftdichip.com/drivers/d2xx-drivers/). Wenn ein FTDI-Gerät zum ersten Mal angeschlossen wird, lädt Windows normalerweise automatisch die D2XX-Treiber herunter, sodass überhaupt keine Aktion erforderlich ist.
-Sollte dies nicht der Fall sein, konsultieren Sie bitte die [FTDI-Installationshandbücher](https://ftdichip.com/document/installation-guides/), um zu erfahren, wie Sie die Treiber installieren.
+Unter Microsoft Windows benötigt das Plugin die [neuesten D2XX-Treiber von FTDI](https://ftdichip.com/drivers/d2xx-drivers/). Wenn ein FTDI-Gerät zum ersten Mal angeschlossen wird, lädt Windows normalerweise automatisch die D2XX-Treiber herunter, sodass überhaupt keine Aktion erforderlich ist.  
+Sollte dies nicht der Fall sein, konsultieren Sie bitte die [FTDI-Installationshandbücher](https://ftdichip.com/document/installation-guides/), um zu erfahren, wie Sie die Treiber installieren.  
 **INSTALLIEREN SIE KEINE VCP-Treiber (Virtual COM Port)**, da diese wahrscheinlich die D2XX-Schnittstelle beeinträchtigen.
 
 Von ENTTEC DMX USB Pro unterstützte Modi

--- a/pages/09.plugins/02.dmx-usb/default.v4_de.md
+++ b/pages/09.plugins/02.dmx-usb/default.v4_de.md
@@ -13,10 +13,10 @@ Unterstützte USB-DMX-Geräte finden Sie auf unserer Seite [Kompatibilität](htt
 Konfiguration
 -------------
 
-DMX-USB-Geräte sollten automatisch von QLC+ erkannt und in der Liste der Eingabe-/Ausgabefelder angezeigt werden.
-Sollte die automatische Erkennung aus irgendeinem Grund fehlschlagen, können Sie den Typ Ihres DMX-USB-Adapters manuell „erzwingen“.
-Klicken Sie auf den Namen Ihres Geräts und öffnen Sie den Konfigurationsdialog, indem Sie unten rechts im Bedienfeld auf das Symbol ![](/basics/configure.png) klicken.
-Sie sehen eine Liste der derzeit an Ihren Computer angeschlossenen DMX-USB-Geräte. Jedes verfügt über ein Dropdown-Menü, in dem Sie den Gerätetyp erzwingen können.
+DMX-USB-Geräte sollten automatisch von QLC+ erkannt und in der Liste der Eingabe-/Ausgabefelder angezeigt werden.  
+Sollte die automatische Erkennung aus irgendeinem Grund fehlschlagen, können Sie den Typ Ihres DMX-USB-Adapters manuell „erzwingen“.  
+Klicken Sie auf den Namen Ihres Geräts und öffnen Sie den Konfigurationsdialog, indem Sie unten rechts im Bedienfeld auf das Symbol ![](/basics/configure.png) klicken.  
+Sie sehen eine Liste der derzeit an Ihren Computer angeschlossenen DMX-USB-Geräte. Jedes verfügt über ein Dropdown-Menü, in dem Sie den Gerätetyp erzwingen können.  
 Hier ist die Bedeutung jedes einzelnen:
 
 * **Open TX**: Enttec USB DMX Open (und Klone) im Ausgabemodus
@@ -27,8 +27,8 @@ Hier ist die Bedeutung jedes einzelnen:
 * **DMX4ALL**: DMX4ALL USB-DMX STAGE-PROFI MK2
 * **Vince Tx**: Vince DMX512 USB im Ausgabemodus
 
-**Hinweis für OSX-Benutzer:** Wenn Ihr Adapter erkannt wird, aber keine Ausgabe erzeugt, finden Sie die Lösung höchstwahrscheinlich auf der Seite [Fragen und Antworten](/basics/questions-and-answers) (Frage #3).
-**Hinweis 1**: Eurolite USB-DMX512 Pro-Geräte müssen in den „Pro RX/TX“-Modus versetzt werden, um ordnungsgemäß zu funktionieren.
+**Hinweis für OSX-Benutzer:** Wenn Ihr Adapter erkannt wird, aber keine Ausgabe erzeugt, finden Sie die Lösung höchstwahrscheinlich auf der Seite [Fragen und Antworten](/basics/questions-and-answers) (Frage #3).  
+**Hinweis 1**: Eurolite USB-DMX512 Pro-Geräte müssen in den „Pro RX/TX“-Modus versetzt werden, um ordnungsgemäß zu funktionieren.  
 **Hinweis 2**: Unter Windows flackern offene DMX-Klone von Enttec möglicherweise mit 44 Hz. Sie können versuchen, die Ausgangsfrequenz zu verringern, bis das Problem behoben ist.
 
 Anforderungen
@@ -36,8 +36,8 @@ Anforderungen
 
 ### Linux
 
-Auf allen Linux-Distributionen müssen Sie libftdi installieren. Wenn Sie QLC+ mit dem Ubuntu Software Center oder einem anderen automatischen Installationstool installieren, wird diese Bibliothek automatisch für Sie installiert.
-In manchen Fällen, wenn das Gerät nichts ausgibt, kann es sinnvoll sein, Ihren Benutzer mit dem folgenden Befehl zur Gruppe „dialout“ hinzuzufügen:
+Auf allen Linux-Distributionen müssen Sie `libftdi` installieren. Wenn Sie QLC+ mit dem Ubuntu Software Center oder einem anderen automatischen Installationstool installieren, wird diese Bibliothek automatisch für Sie installiert.  
+In manchen Fällen, wenn das Gerät nichts ausgibt, kann es sinnvoll sein, Ihren Benutzer mit dem folgenden Befehl zur Gruppe „dialout“ hinzuzufügen:  
 ```
 sudo adduser your\_user\_name dialout
 ```
@@ -57,8 +57,8 @@ Sollte dies nicht der Fall sein, konsultieren Sie bitte die [FTDI-Installationsh
 Von ENTTEC DMX USB Pro unterstützte Modi
 ----------------------------------
 
-Es folgt ein Raster, das die von QLC+ unterstützten E/A-Modi für Geräte wie DMX USB Pro und Pro Mk2 zeigt.
-Wenn ein Modus hier nicht aufgeführt ist, bedeutet dies, dass er aufgrund von Hardwareeinschränkungen nicht von QLC+ oder dem Gerät selbst unterstützt wird. Melden Sie diese daher bitte nicht als Probleme im QLC+-Forum.
+Es folgt ein Raster, das die von QLC+ unterstützten E/A-Modi für Geräte wie DMX USB Pro und Pro Mk2 zeigt.  
+Wenn ein Modus hier nicht aufgeführt ist, bedeutet dies, dass er aufgrund von Hardwareeinschränkungen nicht von QLC+ oder dem Gerät selbst unterstützt wird. Melden Sie diese daher bitte nicht als Probleme im QLC+-Forum.  
 
 
 |               |     |     |     |     |     |     |     |     |     |     |     |     |     |     |
@@ -71,12 +71,12 @@ Wenn ein Modus hier nicht aufgeführt ist, bedeutet dies, dass er aufgrund von H
 | MIDI OUT (2)  |     |     |     |     |     |     |     |     | o   | o   | o   | o   | o   | o   |
 
 
-(1) DMX2 OUT ist nur auf DMX USB Mk2 Pro verfügbar
-(2) MIDI IN und MIDI OUT sind nur beim DMX USB Mk2 Pro mit einem 5-Wege-Breakout-Kabel verfügbar. MIDI OUT-Signale werden von 1 bis 512 gesendet, wie in der [MIDI-Plugin-Kanalzuordnung](../midi#kanalzuordnung) beschrieben.
+(1) DMX2 OUT ist nur auf DMX USB Mk2 Pro verfügbar.  
+(2) MIDI IN und MIDI OUT sind nur beim DMX USB Mk2 Pro mit einem 5-Wege-Breakout-Kabel verfügbar. MIDI OUT-Signale werden von 1 bis 512 gesendet, wie in der [MIDI-Plugin-Kanalzuordnung](../midi#kanalzuordnung) beschrieben.  
 
 Abstimmung
 ------
 
-**Hinweis: Eine manuelle Abstimmung sollte niemals durchgeführt werden, außer in einigen ganz besonderen Fällen. Die Nutzung erfolgt auf eigene Gefahr!**
-Es ist möglich, die DMX-Framegröße für Enttec Open (und ähnliche) Geräte mit einer versteckten Einstellungstaste auf jeder Plattform zu ändern. Der Schlüssel teilt QLC+ mit, wie viele Kanäle in jedem DMX-Frame übertragen werden sollen, also für ein DMX-Universum (standardmäßig 512).
+**Hinweis: Eine manuelle Abstimmung sollte niemals durchgeführt werden, außer in einigen ganz besonderen Fällen. Die Nutzung erfolgt auf eigene Gefahr!**  
+Es ist möglich, die DMX-Framegröße für Enttec Open (und ähnliche) Geräte mit einer versteckten Einstellungstaste auf jeder Plattform zu ändern. Der Schlüssel teilt QLC+ mit, wie viele Kanäle in jedem DMX-Frame übertragen werden sollen, also für ein DMX-Universum (standardmäßig 512).  
 Bitte beachten Sie den Abschnitt [Manuelle Parametereinstellung](/advanced/parameters-tuning#2-dmx-usb-enttec-open-kanalanzahl) DMX USB Enttec Open.

--- a/pages/09.plugins/03.e1-31-sacn/default.v4.md
+++ b/pages/09.plugins/03.e1-31-sacn/default.v4.md
@@ -7,7 +7,7 @@ media_order: e131_configuration.png
 Introduction
 ------------
 
-QLC+ supports the [E1.31 protocol](https://wiki.openlighting.org/index.php/E1.31) (also known as s.ACN) through an input/output plugin that receives and transmits packets on the network.
+QLC+ supports the [E1.31 protocol](https://wiki.openlighting.org/index.php/E1.31) (also known as s.ACN) through an input/output plugin that receives and transmits packets on the network.  
 No extra requirements are needed, since QLC+ has a native implementation of the E1.31 protocol that works on Linux, Windows and OSX systems.  
 The E1.31 plugin can send and receive packets from multiple network cards, virtual addresses, the loopback device (127.0.0.1) and multiple universes per network interface.  
 By default, E1.31 packets will be sent as UDP on multicast addresses like 239.255.0.x, where 'x' is the universe number selected in QLC+. The port used is 5568.  

--- a/pages/09.plugins/03.e1-31-sacn/default.v4_ca.md
+++ b/pages/09.plugins/03.e1-31-sacn/default.v4_ca.md
@@ -7,7 +7,7 @@ media_order: e131_configuration.png
 Introducció
 ------------
 
-QLC+ suporta el protocol [E1.31](https://wiki.openlighting.org/index.php/E1.31) (també conegut com a sACN) a través d'un connector d'entrada/sortida que rep i transmet paquets a la xarxa.
+QLC+ suporta el protocol [E1.31](https://wiki.openlighting.org/index.php/E1.31) (també conegut com a sACN) a través d'un connector d'entrada/sortida que rep i transmet paquets a la xarxa.  
 No es necessiten requisits addicionals, ja que QLC+ té una implementació nativa del protocol E1.31 que funciona en sistemes Linux, Windows i OSX.  
 El connector E1.31 pot enviar i rebre paquets de múltiples targetes de xarxa, adreces virtuals, el dispositiu de bucle/loopback (127.0.0.1) i múltiples universos per interfície de xarxa.  
 Per defecte, els paquets E1.31 s'enviaran com UDP en adreces multicast com 239.255.0.x, on "x" és el número d'univers seleccionat a QLC+. El port utilitzat és 5568.  

--- a/pages/09.plugins/03.e1-31-sacn/default.v4_de.md
+++ b/pages/09.plugins/03.e1-31-sacn/default.v4_de.md
@@ -8,27 +8,27 @@ Einführung
 ------------
 
 QLC+ unterstützt das [E1.31-Protokoll](https://wiki.openlighting.org/index.php/E1.31) (auch bekannt als s.ACN) über ein Eingabe-/Ausgabe-Plugin, das Pakete im Netzwerk empfängt und überträgt.  
-Es sind keine zusätzlichen Anforderungen erforderlich, da QLC+ über eine native Implementierung des E1.31-Protokolls verfügt, das auf Linux-, Windows- und OSX-Systemen funktioniert.
-Das E1.31-Plugin kann Pakete von mehreren Netzwerkkarten, virtuellen Adressen, dem Loopback-Gerät (127.0.0.1) und mehreren Universen pro Netzwerkschnittstelle senden und empfangen.
-Standardmäßig werden E1.31-Pakete als UDP an Multicast-Adressen wie 239.255.0.x gesendet, wobei „x“ die in QLC+ ausgewählte Universumsnummer ist. Der verwendete Port ist 5568.
-Bei Verwendung des Loopback-Geräts werden Pakete immer über die Adresse 127.0.0.1 übertragen.
-Bei der Übertragung mehrerer Universen auf derselben Schnittstelle werden die Pakete standardmäßig mit einer E1.31-Universum-ID gesendet, die dem QLC+-Universum entspricht.
+Es sind keine zusätzlichen Anforderungen erforderlich, da QLC+ über eine native Implementierung des E1.31-Protokolls verfügt, das auf Linux-, Windows- und OSX-Systemen funktioniert.  
+Das E1.31-Plugin kann Pakete von mehreren Netzwerkkarten, virtuellen Adressen, dem Loopback-Gerät (127.0.0.1) und mehreren Universen pro Netzwerkschnittstelle senden und empfangen.  
+Standardmäßig werden E1.31-Pakete als UDP an Multicast-Adressen wie 239.255.0.x gesendet, wobei „x“ die in QLC+ ausgewählte Universumsnummer ist. Der verwendete Port ist 5568.  
+Bei Verwendung des Loopback-Geräts werden Pakete immer über die Adresse 127.0.0.1 übertragen.  
+Bei der Übertragung mehrerer Universen auf derselben Schnittstelle werden die Pakete standardmäßig mit einer E1.31-Universum-ID gesendet, die dem QLC+-Universum entspricht.  
 
-Zum Beispiel:
-QLC+ Universum 1 -> E1.31 Universum 1 auf 239.255.0.1
-QLC+ Universum 2 -> E1.31 Universum 2 auf 239.255.0.2
-...
-QLC+ Universum 8 -> E1.31 Universum 8 auf 239.255.0.8
+Zum Beispiel:  
+QLC+ Universum 1 -> E1.31 Universum 1 auf 239.255.0.1  
+QLC+ Universum 2 -> E1.31 Universum 2 auf 239.255.0.2  
+...  
+QLC+ Universum 8 -> E1.31 Universum 8 auf 239.255.0.8  
 
 Sollten die oben genannten Einstellungen nicht den Anforderungen Ihres Netzwerks entsprechen, lesen Sie bitte das folgende Kapitel.
 
 Konfiguration
 -------------
 
-Wenn Sie auf die Konfigurationsschaltfläche ![](/basics/configure.png) klicken, wird ein kleiner Dialog mit dem Bereich „Universenkonfiguration“ angezeigt.
+Wenn Sie auf die Konfigurationsschaltfläche ![](/basics/configure.png) klicken, wird ein kleiner Dialog mit dem Bereich „Universenkonfiguration“ angezeigt.  
 
-Nachdem ein QLC+-Universum mit einem E1.31-Ein- oder -Ausgang gepatcht wurde, wird in dieser Liste ein Eintrag angezeigt, der es ermöglicht, die gewünschten Parameter, die vom E1.31-Plugin verwendet werden sollen, manuell zu konfigurieren.
-Eingabezeilen können mit folgenden Parametern konfiguriert werden:
+Nachdem ein QLC+-Universum mit einem E1.31-Ein- oder -Ausgang gepatcht wurde, wird in dieser Liste ein Eintrag angezeigt, der es ermöglicht, die gewünschten Parameter, die vom E1.31-Plugin verwendet werden sollen, manuell zu konfigurieren.  
+Eingabezeilen können mit folgenden Parametern konfiguriert werden:  
 
 |     |     |
 | --- | --- |
@@ -42,10 +42,10 @@ Beispiel für eine Eingabekonfiguration:
 
 ![](e131_configuration.png)
 
-Wenn in diesem Beispiel E1.31-Pakete an der Adresse 127.0.0.1 und Port 8000 empfangen werden, wirken sich die Pakete, die auf E1.31-Universum 4 laufen, auf QLC+-Universum 1 aus.
-Außerdem übertragen wir QLC+-Universum 2 auf der Multicast-Adresse 239.255.0.2, E1.31-Universum 1 und QLC+-Universum 3 auf der Unicast-Adresse 13.0.0.175, Port 7000, E1.31-Universum 2.
+Wenn in diesem Beispiel E1.31-Pakete an der Adresse 127.0.0.1 und Port 8000 empfangen werden, wirken sich die Pakete, die auf E1.31-Universum 4 laufen, auf QLC+-Universum 1 aus.  
+Außerdem übertragen wir QLC+-Universum 2 auf der Multicast-Adresse 239.255.0.2, E1.31-Universum 1 und QLC+-Universum 3 auf der Unicast-Adresse 13.0.0.175, Port 7000, E1.31-Universum 2.  
 
-Ausgabeleitungen können mit folgenden Parametern konfiguriert werden:
+Ausgabeleitungen können mit folgenden Parametern konfiguriert werden:  
 
 |     |     |
 | --- | --- |

--- a/pages/09.plugins/03.e1-31-sacn/default.v4_de.md
+++ b/pages/09.plugins/03.e1-31-sacn/default.v4_de.md
@@ -7,7 +7,7 @@ media_order: e131_configuration.png
 Einführung
 ------------
 
-QLC+ unterstützt das [E1.31-Protokoll](https://wiki.openlighting.org/index.php/E1.31) (auch bekannt als s.ACN) über ein Eingabe-/Ausgabe-Plugin, das Pakete im Netzwerk empfängt und überträgt.
+QLC+ unterstützt das [E1.31-Protokoll](https://wiki.openlighting.org/index.php/E1.31) (auch bekannt als s.ACN) über ein Eingabe-/Ausgabe-Plugin, das Pakete im Netzwerk empfängt und überträgt.  
 Es sind keine zusätzlichen Anforderungen erforderlich, da QLC+ über eine native Implementierung des E1.31-Protokolls verfügt, das auf Linux-, Windows- und OSX-Systemen funktioniert.
 Das E1.31-Plugin kann Pakete von mehreren Netzwerkkarten, virtuellen Adressen, dem Loopback-Gerät (127.0.0.1) und mehreren Universen pro Netzwerkschnittstelle senden und empfangen.
 Standardmäßig werden E1.31-Pakete als UDP an Multicast-Adressen wie 239.255.0.x gesendet, wobei „x“ die in QLC+ ausgewählte Universumsnummer ist. Der verwendete Port ist 5568.

--- a/pages/09.plugins/04.hid/default.v4_de.md
+++ b/pages/09.plugins/04.hid/default.v4_de.md
@@ -6,8 +6,8 @@ date: '05:13 22-08-2023'
 Einführung
 ------------
 
-Das HID-Plugin unterstützt das [HID-System](https://de.wikipedia.org/wiki/Human_Interface_Device) unter Windows und Linux.
-HID ist eine generische Methode zur Zuordnung von Eingabe-/Ausgabegeräten wie Joysticks, Touchpads, Tastaturen, Mäusen usw.
+Das HID-Plugin unterstützt das [HID-System](https://de.wikipedia.org/wiki/Human_Interface_Device) unter Windows und Linux.  
+HID ist eine generische Methode zur Zuordnung von Eingabe-/Ausgabegeräten wie Joysticks, Touchpads, Tastaturen, Mäusen usw.  
 Das QLC+ HID-Plugin soll nur Joysticks und den FX5 USB DMX-Adapter unterstützen.
 
 Anforderungen
@@ -18,8 +18,8 @@ Für dieses Plugin sind keine besonderen Anforderungen erforderlich. Stellen Sie
 Joysticks
 ---------
 
-QLC+ versucht, die spezifischen Joystick-Funktionen, wie Achsen und Tasten, als einzelne Kanäle zu erkennen, die Ihren Widgets der virtuellen Konsole zugeordnet werden können.
-Achsen und Tasten werden von QLC+ in sequentieller Reihenfolge zugeordnet. Wenn Ihr Joystick also beispielsweise 2 Achsen und 4 Tasten unterstützt, werden sie in den Eingabezuordnungsdialogen wie folgt angezeigt:
+QLC+ versucht, die spezifischen Joystick-Funktionen, wie Achsen und Tasten, als einzelne Kanäle zu erkennen, die Ihren Widgets der virtuellen Konsole zugeordnet werden können.  
+Achsen und Tasten werden von QLC+ in sequentieller Reihenfolge zugeordnet. Wenn Ihr Joystick also beispielsweise 2 Achsen und 4 Tasten unterstützt, werden sie in den Eingabezuordnungsdialogen wie folgt angezeigt:  
 
 * Kanal 1: X-Achse
 * Kanal 2: Y-Achse

--- a/pages/09.plugins/06.midi/default.v4_de.md
+++ b/pages/09.plugins/06.midi/default.v4_de.md
@@ -6,14 +6,14 @@ date: '05:15 22-08-2023'
 Einführung
 ------------
 
-Dieses Plugin bietet Ein-/Ausgabeunterstützung für das [MIDI-Protokoll](https://de.wikipedia.org/wiki/MIDI) und gibt dem Benutzer die Freiheit, typische Parameter wie Kanäle, Noten, Programmwechsel und Kontrollwechsel zu steuern.
-Das MIDI-Plugin kann sehr leistungsstark in Kombination mit MIDI-Geräten wie Keyboards, MIDI-Controllern (wie Behringer BCF2000 oder KORG nanoKONTROL) oder einem Software-Audiosequenzer wie Cubase oder Ardour 3 verwendet werden.
+Dieses Plugin bietet Ein-/Ausgabeunterstützung für das [MIDI-Protokoll](https://de.wikipedia.org/wiki/MIDI) und gibt dem Benutzer die Freiheit, typische Parameter wie Kanäle, Noten, Programmwechsel und Kontrollwechsel zu steuern.  
+Das MIDI-Plugin kann sehr leistungsstark in Kombination mit MIDI-Geräten wie Keyboards, MIDI-Controllern (wie Behringer BCF2000 oder KORG nanoKONTROL) oder einem Software-Audiosequenzer wie Cubase oder Ardour 3 verwendet werden.  
 Die Verwendung kann von Fader-zu-Fader-Steuerung (im BCF2000-Fall) bis hin zur Sequenzauslösung für synchronisierte Shows (metronomgesteuerte Gigs mit einem Audiosequenzer) variieren.
 
 Konfiguration
 -------------
 
-Wenn Sie auf die Konfigurationsschaltfläche ![](/basics/configure.png) klicken, erscheint ein Fenster, das alle erkannten MIDI-Ein- und Ausgangsleitungen anzeigt.
+Wenn Sie auf die Konfigurationsschaltfläche ![](/basics/configure.png) klicken, erscheint ein Fenster, das alle erkannten MIDI-Ein- und Ausgangsleitungen anzeigt.  
 Jede Zeile verfügt über drei Optionen, die je nach Bedarf geändert werden können:
 
 * **MIDI-Kanal**: Dies ist der Kanal, auf dem QLC+ Daten über das MIDI-System empfängt oder sendet. MIDI-Kanäle können von 1 bis 16 reichen. Der spezielle Kanal „1-16“ weist QLC+ an, Daten auf jedem MIDI-Kanal zu empfangen oder zu senden.
@@ -26,10 +26,10 @@ Jede Zeile verfügt über drei Optionen, die je nach Bedarf geändert werden kö
 Rückmeldung
 ---------
 
-Das MIDI-Plugin ist eines der QLC+-Plugins, die Feedback unterstützen. Wenn QLC+ ein MIDI-Gerät mit einer Ausgangsleitung erkennt, aktiviert es das Feedback-Kontrollkästchen im [Eingabe-/Ausgabefeld](/input-output). Bitte beachten Sie, dass Ausgabe und Feedback exklusiv sind und daher nicht beide gleichzeitig verwendet werden können.
-Wenn Ihr MIDI-Gerät einen Rückkanal unterstützt, kann QLC+ ein visuelles/mechanisches Feedback an ihn senden. Geräte wie das Behringer BCF2000 unterstützen diese Funktion. Dies ist bei Live-Shows sehr nützlich, um sofort über den aktuellen Status der in QLC+ zugeordneten Fader informiert zu sein.
+Das MIDI-Plugin ist eines der QLC+-Plugins, die Feedback unterstützen. Wenn QLC+ ein MIDI-Gerät mit einer Ausgangsleitung erkennt, aktiviert es das Feedback-Kontrollkästchen im [Eingabe-/Ausgabefeld](/input-output). Bitte beachten Sie, dass Ausgabe und Feedback exklusiv sind und daher nicht beide gleichzeitig verwendet werden können.  
+Wenn Ihr MIDI-Gerät einen Rückkanal unterstützt, kann QLC+ ein visuelles/mechanisches Feedback an ihn senden. Geräte wie das Behringer BCF2000 unterstützen diese Funktion. Dies ist bei Live-Shows sehr nützlich, um sofort über den aktuellen Status der in QLC+ zugeordneten Fader informiert zu sein.  
 
-Ein kleiner Trick, der mit QLC+ erreicht werden kann, besteht darin, Feedback als generische MIDI-Ausgangsleitung zum Triggern externer Controller/Sequenzer zu verwenden.
+Ein kleiner Trick, der mit QLC+ erreicht werden kann, besteht darin, Feedback als generische MIDI-Ausgangsleitung zum Triggern externer Controller/Sequenzer zu verwenden.  
 Schauen wir uns einige Beispiele an:
 
 * Eingang: **OSC** ---\> Ausgang: **DMX USB** --\> Feedback: **MIDI**
@@ -43,10 +43,10 @@ Aus unbekannten Gründen wird in den Werkseinstellungen des nanoPAD die X-Achse 
 AKAI APC LED-Feedback
 ----------------------
 
-Bei der Verwendung eines der AKAI APC-Controller gibt es eine Funktion, die sehr praktisch sein kann: LED-Farbrückmeldung.
-Das Standardverhalten der Tasten der virtuellen Konsole ist: Wert = 0: LED aus, Wert = 255: LED grün
-Dies kann bei der Auswahl eines Eingangskanals durch Drücken der Schaltfläche „Benutzerdefiniertes Feedback“ angepasst werden.
-Es erscheint ein neuer Bereich mit der Möglichkeit, einen unteren und einen oberen Wert einzugeben. Dabei handelt es sich grundsätzlich um die Werte, die QLC+ für den Ein-/Aus-Zustand der Tasten senden soll.
+Bei der Verwendung eines der AKAI APC-Controller gibt es eine Funktion, die sehr praktisch sein kann: LED-Farbrückmeldung.  
+Das Standardverhalten der Tasten der virtuellen Konsole ist: Wert = 0: LED aus, Wert = 255: LED grün.  
+Dies kann bei der Auswahl eines Eingangskanals durch Drücken der Schaltfläche „Benutzerdefiniertes Feedback“ angepasst werden.  
+Es erscheint ein neuer Bereich mit der Möglichkeit, einen unteren und einen oberen Wert einzugeben. Dabei handelt es sich grundsätzlich um die Werte, die QLC+ für den Ein-/Aus-Zustand der Tasten senden soll.  
 Da das MIDI-Protokoll in einem Wertebereich von 0–127 arbeitet und QLC+ im DMX-Bereich von 0–255 arbeitet, zeigt Ihnen die folgende Tabelle direkt die Werte, die Sie eingeben sollten, um die gewünschte Farbe einer APC-LED zu erhalten. Im Wesentlichen sind sie den APC-Handbüchern entnommen und verdoppelt.
 
 | Wert | LED-Farbe |
@@ -65,16 +65,16 @@ Es ist interessant zu bemerken, dass Sie nicht unbedingt 0 als unteren Wert beib
 MIDI-Beat-Clock
 ---------------
 
-Ab Version 4.5.0 unterstützt QLC+ die [MIDI-Beat-Clock](https://en.wikipedia.org/wiki/MIDI_beat_clock)
-Nicht zu verwechseln mit dem [MIDI-Timecode](https://en.wikipedia.org/wiki/MIDI_timecode), die MIDI-Beat-Clock ist ein nützliches Signal, um BPM-basierte Geräte wie einen Drumcomputer mit Ihren von ihm gesteuerten Lichtern zu synchronisieren QLC+.
-In QLC+ wurden zwei spezielle MIDI-Kanäle zugeordnet, um Ihre [Virtual Console](/virtual-console)-Widgets mit einer Beat-Clock zu steuern.
+Ab Version 4.5.0 unterstützt QLC+ die [MIDI-Beat-Clock](https://en.wikipedia.org/wiki/MIDI_beat_clock).  
+Nicht zu verwechseln mit dem [MIDI-Timecode](https://en.wikipedia.org/wiki/MIDI_timecode), die MIDI-Beat-Clock ist ein nützliches Signal, um BPM-basierte Geräte wie einen Drumcomputer mit Ihren von ihm gesteuerten Lichtern zu synchronisieren QLC+.  
+In QLC+ wurden zwei spezielle MIDI-Kanäle zugeordnet, um Ihre [Virtual Console](/virtual-console)-Widgets mit einer Beat-Clock zu steuern.  
 Hier eine kurze Erklärung der Sonderkanäle:
 
 * **Kanal 530**: Auf diesem Kanal wird ein Signal gesendet, wenn eine Beat Clock startet oder stoppt.
 * **Kanal 531**: Dieses Signal wird alle BPM gesendet. QLC+ berücksichtigt keine Takte (z. B. 3/4, 4/4, 7/8), daher müssen Sie beim Einrichten Ihrer MIDI-Clock berücksichtigen, wie QLC+ damit umgeht.
 
 
-**Hinweis**: Wenn Ihr Controller auf hohe BPM (z. B. 180-200) eingestellt ist, fällt es Ihnen möglicherweise schwer, das Startsignal zu empfangen. Ein Trick hierfür besteht darin, das Stoppsignal abzufangen. Beispiel:
+**Hinweis**: Wenn Ihr Controller auf hohe BPM (z. B. 180-200) eingestellt ist, fällt es Ihnen möglicherweise schwer, das Startsignal zu empfangen. Ein Trick hierfür besteht darin, das Stoppsignal abzufangen. Beispiel:  
 
 1. Aktivieren Sie die automatische Erkennung des QLC+ Virtual Console-Widgets
 2. Drücken Sie auf Ihrem Gerät die Wiedergabetaste, um die MIDI-Beat-Clock zu erzeugen. QLC+ erkennt Kanal 530 und schaltet sehr schnell auf 531 um
@@ -86,10 +86,10 @@ Auf ähnliche Weise können Sie auch das Beat-Signal erfassen. Deaktivieren Sie 
 MIDI-Initialisierungsnachricht
 -------------
 
-Es kann vorkommen, dass Ihr MIDI-Gerät einige Befehle benötigt, um in einen bestimmten Betriebsmodus zu wechseln
-Das MIDI-Protokoll kann dies über SysEx bewältigen. Hierbei handelt es sich um bestimmte Nachrichten, die einem MIDI-Gerät Anweisungen zum Verhalten geben.
-QLC+ kann dazu eine XML-Vorlage verwenden, die im MIDI-Konfigurationspanel ausgewählt werden kann.
-Hier ist ein Beispiel dafür, wie eine Vorlage aussieht:
+Es kann vorkommen, dass Ihr MIDI-Gerät einige Befehle benötigt, um in einen bestimmten Betriebsmodus zu wechseln.  
+Das MIDI-Protokoll kann dies über SysEx bewältigen. Hierbei handelt es sich um bestimmte Nachrichten, die einem MIDI-Gerät Anweisungen zum Verhalten geben.  
+QLC+ kann dazu eine XML-Vorlage verwenden, die im MIDI-Konfigurationspanel ausgewählt werden kann.  
+Hier ist ein Beispiel dafür, wie eine Vorlage aussieht:  
 
 &lt;!DOCTYPE MidiTemplate&gt;
 &lt;MidiTemplate&gt;
@@ -101,13 +101,13 @@ Hier ist ein Beispiel dafür, wie eine Vorlage aussieht:
  &lt;InitMessage&gt;F0 47 00 7B 60 00 04 41 09 00 05 F7&lt;/InitMessage&gt;
 &lt;/MidiTemplate&gt;
 
-Sie können die benötigten Vorlagen erstellen und in Ihrem MidiTemplates-Ordner ablegen.
+Sie können die benötigten Vorlagen erstellen und in Ihrem MidiTemplates-Ordner ablegen.  
 Sie können diese gerne im QLC+-Forum einreichen.
 
 Kanalzuordnung
 -----------------
 
-Um eine Mischung aus verschiedenen MIDI-Nachrichten (Notes, PC, CC usw.) zu verarbeiten, ordnet QLC+ diese in eine sequentielle Reihenfolge um.
+Um eine Mischung aus verschiedenen MIDI-Nachrichten (Notes, PC, CC usw.) zu verarbeiten, ordnet QLC+ diese in eine sequentielle Reihenfolge um.  
 Nachfolgend die Kanalnummern, die im [Eingabeprofil-Editor](/input-output/input-profiles) verwendet werden sollen:
 
 | Kanal | MIDI-Nachricht |

--- a/pages/09.plugins/07.ola/default.v4.md
+++ b/pages/09.plugins/07.ola/default.v4.md
@@ -13,7 +13,7 @@ Requirements
 
 The OLA plugin requires OLA to be installed on the system.  
 Since OLA doesn't run on Windows, only Linux and macOS users can benefit from this plugin.  
-Information on how to download and install OLA can be found [here](https://wiki.openlighting.org/index.php/Download_%26_Install_OLA).
+Information on how to download and install OLA can be found [here](https://wiki.openlighting.org/index.php/Download_%26_Install_OLA).  
 QLC+ needs the OLA server to be running to be able to communicate with the OLA framework. This can be done either manually by starting up "olad" from a terminal or in the configuration panel by ticking "Run standalone OLA daemon".
 
 Configuration
@@ -26,5 +26,5 @@ OLA Setup
 ---------
 
 When you have made sure that everything is working in QLC+ and have checked how the universes are mapped, you can setup OLA to output the signal received from QLC+ to a DMX device, either USB or over the network.  
-Here's an [introduction of OLA usage](https://wiki.openlighting.org/index.php/Using_OLA).
+Here's an [introduction of OLA usage](https://wiki.openlighting.org/index.php/Using_OLA).  
 Basically you need to open a web browser, connect to [http://localhost:9090](http://localhost:9090) or [http://127.0.0.1:9090](http://127.0.0.1:9090) and add a universe that has the same number mapped in QLC+ and select the desired output line.

--- a/pages/09.plugins/07.ola/default.v4_ca.md
+++ b/pages/09.plugins/07.ola/default.v4_ca.md
@@ -13,7 +13,7 @@ Requisits
 
 El connector OLA requereix que l'OLA s'instal·li al sistema.  
 Com que l'OLA no s'executa al Windows, només els usuaris de Linux i macOS poden beneficiar-se d'aquest connector.  
-Podeu trobar informació sobre com baixar i instal·lar l'OLA [aquí](https://wiki.openlighting.org/index.php/Download_%26_Install_OLA).
+Podeu trobar informació sobre com baixar i instal·lar l'OLA [aquí](https://wiki.openlighting.org/index.php/Download_%26_Install_OLA).  
 QLC+ necessita que el servidor OLA s'estigui executant per poder comunicar-se amb l'entorn de treball OLA. Això es pot fer manualment iniciant "olad" des d'un terminal o al panell de configuració marcant "Executa el dimoni ola independent".
 
 Configuració
@@ -26,5 +26,5 @@ Configuració OLA
 ---------
 
 Quan us heu assegurat que tot està funcionant a QLC+ i heu comprovat com s'han mapejat els universos, podeu configurar OLA per a enviar el senyal rebut de QLC+ a un dispositiu DMX, ja sigui USB o a través de la xarxa.  
-Aquí teniu una introducció [de l'ús de l'OLA](https://wiki.openlighting.org/index.php/Using_OLA).
+Aquí teniu una introducció [de l'ús de l'OLA](https://wiki.openlighting.org/index.php/Using_OLA).  
 Bàsicament cal obrir un navegador web, connectar-se a [http://localhost:9090](http://localhost:9090) o [http://127.0.0.1:9090](http://127.0.0.1:9090) i afegir un univers que tingui el mateix nombre assignat a QLC+ i seleccionar la línia de sortida desitjada.

--- a/pages/09.plugins/07.ola/default.v4_de.md
+++ b/pages/09.plugins/07.ola/default.v4_de.md
@@ -11,20 +11,20 @@ Das OLA-Plugin ermöglicht die direkte Kommunikation zwischen QLC+ und dem [OLA-
 Anforderungen
 ------------
 
-Für das OLA-Plugin muss OLA auf dem System installiert sein.
-Da OLA nicht unter Windows läuft, können nur Linux- und macOS-Benutzer von diesem Plugin profitieren.
+Für das OLA-Plugin muss OLA auf dem System installiert sein.  
+Da OLA nicht unter Windows läuft, können nur Linux- und macOS-Benutzer von diesem Plugin profitieren.  
 Informationen zum Herunterladen und Installieren von OLA finden Sie [hier](https://wiki.openlighting.org/index.php/Download_%26_Install_OLA).  
 QLC+ benötigt den Betrieb des OLA-Servers, um mit dem OLA-Framework kommunizieren zu können. Dies kann entweder manuell durch Starten von „olad“ von einem Terminal aus oder im Konfigurationsfenster durch Ankreuzen von „Standalone OLA Daemon ausführen“ erfolgen.
 
 Konfiguration
 -------------
 
-Wenn Sie die Konfigurationsschaltfläche über einer OLA-Ausgabezeile drücken, erscheint ein kleines Popup-Fenster mit den grundlegenden Informationen darüber, wie QLC+-Ausgaben OLA-Universen zugeordnet werden.
+Wenn Sie die Konfigurationsschaltfläche über einer OLA-Ausgabezeile drücken, erscheint ein kleines Popup-Fenster mit den grundlegenden Informationen darüber, wie QLC+-Ausgaben OLA-Universen zugeordnet werden.  
 Unten können Sie über eine Schaltfläche mit dem Häkchen den Start des OLA-Servers erzwingen.
 
 OLA-Setup
 ---------
 
-Wenn Sie sichergestellt haben, dass in QLC+ alles funktioniert, und überprüft haben, wie die Universen zugeordnet sind, können Sie OLA so einrichten, dass das von QLC+ empfangene Signal an ein DMX-Gerät ausgegeben wird, entweder über USB oder über das Netzwerk.
+Wenn Sie sichergestellt haben, dass in QLC+ alles funktioniert, und überprüft haben, wie die Universen zugeordnet sind, können Sie OLA so einrichten, dass das von QLC+ empfangene Signal an ein DMX-Gerät ausgegeben wird, entweder über USB oder über das Netzwerk.  
 Hier ist eine [Einführung in die OLA-Nutzung](https://wiki.openlighting.org/index.php/Using_OLA).  
 Grundsätzlich müssen Sie einen Webbrowser öffnen und eine Verbindung zu [http://localhost:9090](http://localhost:9090) oder [http://127.0.0.1:9090](http://127.0.0.1) herstellen. 9090) und fügen Sie ein Universum hinzu, dem die gleiche Nummer in QLC+ zugeordnet ist, und wählen Sie die gewünschte Ausgabezeile aus.

--- a/pages/09.plugins/07.ola/default.v4_de.md
+++ b/pages/09.plugins/07.ola/default.v4_de.md
@@ -13,7 +13,7 @@ Anforderungen
 
 Für das OLA-Plugin muss OLA auf dem System installiert sein.
 Da OLA nicht unter Windows läuft, können nur Linux- und macOS-Benutzer von diesem Plugin profitieren.
-Informationen zum Herunterladen und Installieren von OLA finden Sie [hier](https://wiki.openlighting.org/index.php/Download_%26_Install_OLA).
+Informationen zum Herunterladen und Installieren von OLA finden Sie [hier](https://wiki.openlighting.org/index.php/Download_%26_Install_OLA).  
 QLC+ benötigt den Betrieb des OLA-Servers, um mit dem OLA-Framework kommunizieren zu können. Dies kann entweder manuell durch Starten von „olad“ von einem Terminal aus oder im Konfigurationsfenster durch Ankreuzen von „Standalone OLA Daemon ausführen“ erfolgen.
 
 Konfiguration
@@ -26,5 +26,5 @@ OLA-Setup
 ---------
 
 Wenn Sie sichergestellt haben, dass in QLC+ alles funktioniert, und überprüft haben, wie die Universen zugeordnet sind, können Sie OLA so einrichten, dass das von QLC+ empfangene Signal an ein DMX-Gerät ausgegeben wird, entweder über USB oder über das Netzwerk.
-Hier ist eine [Einführung in die OLA-Nutzung](https://wiki.openlighting.org/index.php/Using_OLA).
+Hier ist eine [Einführung in die OLA-Nutzung](https://wiki.openlighting.org/index.php/Using_OLA).  
 Grundsätzlich müssen Sie einen Webbrowser öffnen und eine Verbindung zu [http://localhost:9090](http://localhost:9090) oder [http://127.0.0.1:9090](http://127.0.0.1) herstellen. 9090) und fügen Sie ein Universum hinzu, dem die gleiche Nummer in QLC+ zugeordnet ist, und wählen Sie die gewünschte Ausgabezeile aus.

--- a/pages/09.plugins/08.os2l/default.v4.md
+++ b/pages/09.plugins/08.os2l/default.v4.md
@@ -7,7 +7,7 @@ Introduction
 ------------
 
 The OS2L plugin allows direct communication between QLC+ and an OS2L capable host.  
-OS2L specifications can be found at: [https://os2l.org](https://os2l.org/)
+OS2L specifications can be found at: [https://os2l.org](https://os2l.org/)  
 At the moment the only OS2L host supported is [Virtual DJ](https://www.virtualdj.com/).  
 QLC+ OS2L plugin will work either on the same host (127.0.0.1) or on a different host with an OS of your choice (Windows, macOS, Linux)
 

--- a/pages/09.plugins/08.os2l/default.v4_ca.md
+++ b/pages/09.plugins/08.os2l/default.v4_ca.md
@@ -7,7 +7,7 @@ Introducció
 ------------
 
 El connector OS2L permet la comunicació directa entre QLC+ i un amfitrió compatible amb OS2L.  
-Les especificacions d'OS2L es poden trobar a: [https://os2l.org](https://os2l.org/)
+Les especificacions d'OS2L es poden trobar a: [https://os2l.org](https://os2l.org/)  
 De moment, l'únic amfitrió OS2L compatible és [Virtual DJ](https://www.virtualdj.com/).  
 El connector QLC+ OS2L funcionarà en el mateix amfitrió (127.0.0.1) o en un amfitrió diferent amb un sistema operatiu de la vostra elecció (Windows, macOS, Linux)
 

--- a/pages/09.plugins/08.os2l/default.v4_de.md
+++ b/pages/09.plugins/08.os2l/default.v4_de.md
@@ -6,20 +6,20 @@ date: '05:18 22-08-2023'
 Einführung
 ------------
 
-Das OS2L-Plugin ermöglicht die direkte Kommunikation zwischen QLC+ und einem OS2L-fähigen Host.
+Das OS2L-Plugin ermöglicht die direkte Kommunikation zwischen QLC+ und einem OS2L-fähigen Host.  
 OS2L-Spezifikationen finden Sie unter: [https://os2l.org](https://os2l.org/)  
-Derzeit ist der einzige unterstützte OS2L-Host [Virtual DJ](https://www.virtualdj.com/).
+Derzeit ist der einzige unterstützte OS2L-Host [Virtual DJ](https://www.virtualdj.com/).  
 Das QLC+ OS2L-Plugin funktioniert entweder auf demselben Host (127.0.0.1) oder auf einem anderen Host mit einem Betriebssystem Ihrer Wahl (Windows, macOS, Linux).
 
 Konfiguration – Virtueller DJ
 --------------------------
 
-Zuallererst müssen Sie VDJ mitteilen, wohin OS2L-Nachrichten gesendet werden sollen.
-Öffnen Sie die VDJ-Einstellungen, gehen Sie zum Bereich „Optionen“ und geben Sie „os2l“ in das obere Suchfeld ein.
-Ändern Sie das Feld „os2lDirectIp“, indem Sie den IP-Port festlegen, über den VDJ QLC+ erreichen kann. Beispielsweise sollte „127.0.0.1:9996“ funktionieren, wenn QLC+ auf demselben (Windows-)PC von VDJ läuft.
-Wenn Sie fertig sind, starten Sie VDJ neu.
+Zuallererst müssen Sie VDJ mitteilen, wohin OS2L-Nachrichten gesendet werden sollen.  
+Öffnen Sie die VDJ-Einstellungen, gehen Sie zum Bereich „Optionen“ und geben Sie „os2l“ in das obere Suchfeld ein.  
+Ändern Sie das Feld „os2lDirectIp“, indem Sie den IP-Port festlegen, über den VDJ QLC+ erreichen kann. Beispielsweise sollte „127.0.0.1:9996“ funktionieren, wenn QLC+ auf demselben (Windows-)PC von VDJ läuft.  
+Wenn Sie fertig sind, starten Sie VDJ neu.  
 
-Gehen Sie nun zu QLC+ und aktivieren Sie das OS2L-Plugin in einem beliebigen Universum. Wenn Sie in VDJ einen bestimmten Port festgelegt haben, öffnen Sie den OS2L-Konfigurationsdialog und stellen Sie dort denselben Port ein.
+Gehen Sie nun zu QLC+ und aktivieren Sie das OS2L-Plugin in einem beliebigen Universum. Wenn Sie in VDJ einen bestimmten Port festgelegt haben, öffnen Sie den OS2L-Konfigurationsdialog und stellen Sie dort denselben Port ein.  
 Sobald dies erledigt ist, beginnt QLC+, Signale von VDJ zu empfangen (das Joystick-Symbol blinkt neben dem Universe-Feld).
 
 Client-Konfiguration

--- a/pages/09.plugins/08.os2l/default.v4_de.md
+++ b/pages/09.plugins/08.os2l/default.v4_de.md
@@ -7,7 +7,7 @@ Einführung
 ------------
 
 Das OS2L-Plugin ermöglicht die direkte Kommunikation zwischen QLC+ und einem OS2L-fähigen Host.
-OS2L-Spezifikationen finden Sie unter: [https://os2l.org](https://os2l.org/)
+OS2L-Spezifikationen finden Sie unter: [https://os2l.org](https://os2l.org/)  
 Derzeit ist der einzige unterstützte OS2L-Host [Virtual DJ](https://www.virtualdj.com/).
 Das QLC+ OS2L-Plugin funktioniert entweder auf demselben Host (127.0.0.1) oder auf einem anderen Host mit einem Betriebssystem Ihrer Wahl (Windows, macOS, Linux).
 

--- a/pages/09.plugins/09.osc/default.v4_de.md
+++ b/pages/09.plugins/09.osc/default.v4_de.md
@@ -6,35 +6,35 @@ date: '05:18 22-08-2023'
 Einführung
 ------------
 
-QLC+ unterstützt das [OSC-Protokoll](https://de.wikipedia.org/wiki/Open_Sound_Control) über ein Eingabe-/Ausgabe-Plugin, das Pakete im Netzwerk empfängt und überträgt.
-Es sind keine zusätzlichen Anforderungen erforderlich, da QLC+ über eine native Implementierung des OSC-Protokolls verfügt, das auf Linux-, Windows- und OSX-Systemen funktioniert.
-Das OSC-Plugin kann Pakete von mehreren Netzwerkkarten, virtuellen Adressen, dem Loopback-Gerät (127.0.0.1) und mehreren Universen pro Netzwerkschnittstelle senden und empfangen.
-Standardmäßig überwacht das OSC-Plugin Ports ab 7700 plus dem QLC+-Universum minus eins.
-Die Ausgabe verwendet stattdessen Ports ab 9000 plus dem QLC+-Universum minus eins.
+QLC+ unterstützt das [OSC-Protokoll](https://de.wikipedia.org/wiki/Open_Sound_Control) über ein Eingabe-/Ausgabe-Plugin, das Pakete im Netzwerk empfängt und überträgt.  
+Es sind keine zusätzlichen Anforderungen erforderlich, da QLC+ über eine native Implementierung des OSC-Protokolls verfügt, das auf Linux-, Windows- und OSX-Systemen funktioniert.  
+Das OSC-Plugin kann Pakete von mehreren Netzwerkkarten, virtuellen Adressen, dem Loopback-Gerät (127.0.0.1) und mehreren Universen pro Netzwerkschnittstelle senden und empfangen.  
+Standardmäßig überwacht das OSC-Plugin Ports ab 7700 plus dem QLC+-Universum minus eins.  
+Die Ausgabe verwendet stattdessen Ports ab 9000 plus dem QLC+-Universum minus eins.  
 
-Zum Beispiel:
-QLC+ Universe 1 -> OSC-Eingangsport 7700, Ausgangsport 9000
-QLC+ Universe 2 -> OSC-Eingangsport 7701, Ausgangsport 9001
-...
-QLC+ Universe 8 -> OSC-Eingangsport 7707, Ausgangsport 9007
+Zum Beispiel:  
+QLC+ Universe 1 -> OSC-Eingangsport 7700, Ausgangsport 9000  
+QLC+ Universe 2 -> OSC-Eingangsport 7701, Ausgangsport 9001  
+...  
+QLC+ Universe 8 -> OSC-Eingangsport 7707, Ausgangsport 9007  
 
 
 Konfiguration
 -------------
 
-Wenn Sie auf die Konfigurationsschaltfläche ![](/basics/configure.png) klicken, wird ein kleiner Dialog mit dem Bereich „Universenkonfiguration“ angezeigt.
+Wenn Sie auf die Konfigurationsschaltfläche ![](/basics/configure.png) klicken, wird ein kleiner Dialog mit dem Bereich „Universenkonfiguration“ angezeigt.  
 
-Nachdem ein QLC+-Universum mit einem OSC-Ein- oder -Ausgang gepatcht wurde, wird in dieser Liste ein Eintrag angezeigt, der es ermöglicht, die gewünschten Parameter, die vom OSC-Plugin verwendet werden sollen, manuell zu konfigurieren.
+Nachdem ein QLC+-Universum mit einem OSC-Ein- oder -Ausgang gepatcht wurde, wird in dieser Liste ein Eintrag angezeigt, der es ermöglicht, die gewünschten Parameter, die vom OSC-Plugin verwendet werden sollen, manuell zu konfigurieren.  
 
 Für jeden OSC-Ein- oder -Ausgang können folgende Parameter eingestellt werden:
 
 * **Eingangsport:** Wenn die gepatchte Leitung zur Eingabe geöffnet ist, definiert dieser Parameter den Port, den QLC+ abhört, um OSC-Daten von Ihrem externen Controller zu empfangen.
-* **Ausgabeadresse:** Wenn die gepatchte Leitung zur Eingabe geöffnet ist, ist dies die Ziel-IP-Adresse, die zum Senden von Rückmeldungen an Ihren externen Controller verwendet wird.
-    Wenn die gepatchte Leitung zur Ausgabe geöffnet ist, ist dies die Ziel-IP-Adresse, die zum Senden von OSC-Daten im Netzwerk verwendet wird.
-    OSC-Ausgabepakete werden zusammengesetzt, um einen OSC-Pfad wie den folgenden zu erhalten: /QLC+-Universum – 1/dmx/DMX-Kanal – 1
-    Kanal 12 des QLC+-Universums 4 hat beispielsweise den folgenden Pfad: /3/dmx/11
+* **Ausgabeadresse:** Wenn die gepatchte Leitung zur Eingabe geöffnet ist, ist dies die Ziel-IP-Adresse, die zum Senden von Rückmeldungen an Ihren externen Controller verwendet wird.  
+    Wenn die gepatchte Leitung zur Ausgabe geöffnet ist, ist dies die Ziel-IP-Adresse, die zum Senden von OSC-Daten im Netzwerk verwendet wird.  
+    OSC-Ausgabepakete werden zusammengesetzt, um einen OSC-Pfad wie den folgenden zu erhalten: /QLC+-Universum – 1/dmx/DMX-Kanal – 1  
+    Kanal 12 des QLC+-Universums 4 hat beispielsweise den folgenden Pfad: /3/dmx/11  
     Alle vom OSC-Plugin übermittelten Werte verwenden den Typ float.
-* **Ausgabeport:** Wenn die gepatchte Leitung für die Eingabe geöffnet ist, ist dies der Zielport, der zum Senden von Rückmeldungen an Ihren externen Controller verwendet wird.
+* **Ausgabeport:** Wenn die gepatchte Leitung für die Eingabe geöffnet ist, ist dies der Zielport, der zum Senden von Rückmeldungen an Ihren externen Controller verwendet wird.  
     Wenn die gepatchte Leitung zur Ausgabe geöffnet ist, ist dies der Zielport, der zum Senden von OSC-Daten im Netzwerk verwendet wird.
 
 **Hinweis:** Beim Patchen einer Input+Feedback-Leitung müssen Sie die Ausgangs-IP/den Port ändern, die im Abschnitt „Eingänge“ aufgeführt sind. Behalten Sie einfach den Abschnitt „Ausgaben“ als Standard bei.
@@ -42,8 +42,8 @@ Für jeden OSC-Ein- oder -Ausgang können folgende Parameter eingestellt werden:
 Kanalrechner
 -------------
 
-Wenn es keine Möglichkeit gibt, eine automatische Erkennung über den Eingabeprofil-Editor eines OSC-Controllers durchzuführen, könnte Ihnen dieses Tool helfen.
-Sie können den **OSC-Pfad** eingeben und QLC+ berechnet die Kanalnummer für Sie. Es handelt sich im Grunde um einen 16-Bit-Hash des Pfads, den QLC+ zur Darstellung einer OSC-Eingabe verwendet.
+Wenn es keine Möglichkeit gibt, eine automatische Erkennung über den Eingabeprofil-Editor eines OSC-Controllers durchzuführen, könnte Ihnen dieses Tool helfen.  
+Sie können den **OSC-Pfad** eingeben und QLC+ berechnet die Kanalnummer für Sie. Es handelt sich im Grunde um einen 16-Bit-Hash des Pfads, den QLC+ zur Darstellung einer OSC-Eingabe verwendet.  
 
 **Hinweis:** Zwischen dem Rechner und dem, was Sie im Eingabeprofil-Editor sehen, besteht ein Versatz von 1. Dies ist in Ordnung, da Kanäle in QLC+ bei 1 und nicht bei 0 beginnen. Was der Rechner anzeigt, ist die Kanalnummer, die Sie tatsächlich in ein Eingabeprofil oder in Ihren benutzerdefinierten OSC-Controller schreiben müssen.
 

--- a/pages/09.plugins/10.peperoni/default.v4_de.md
+++ b/pages/09.plugins/10.peperoni/default.v4_de.md
@@ -21,7 +21,7 @@ Für Mac OS
 
 ### Windows
 
-Sie müssen die [Peperoni USBDMX Windows-Treiber](http://www.lighting-solutions.de/support/driver.html) installieren. Normalerweise liegen diese zusammen mit dem Peperoni-Gerät, das Sie gekauft haben, auf einer CD bei.
+Sie müssen die [Peperoni USBDMX Windows-Treiber](http://www.lighting-solutions.de/support/driver.html) installieren. Normalerweise liegen diese zusammen mit dem Peperoni-Gerät, das Sie gekauft haben, auf einer CD bei.  
 Wenn QLC+ Ihr Peperoni-Gerät nach der Installation des Treibers immer noch nicht erkennt, kopieren Sie die Datei usbdmx.dll, die Sie im Treiber-ZIP-Paket (Ordner i386) finden, in den Hauptordner von QLC+.
 
 * Entpacken Sie das Treiberpaket in einen Ordner auf Ihrer Festplatte.

--- a/pages/09.plugins/disable-apple-serial-vcp-driver/default.v4.md
+++ b/pages/09.plugins/disable-apple-serial-vcp-driver/default.v4.md
@@ -55,7 +55,7 @@ The kextunload and kextload commands can be run in any directory.
 Note: this is the only non-temporary method which works on **10.11 El Capitan**.  
   
 FTDI provides a signed kernel extension (D2xxHelper.kext) which contains no code but acts to prevent OS X from matching an FTDI chip (with standard vendor and product identifiers) with a VCP driver, either Apple's or FTDI's. This leaves the device unclaimed, and available for D2XX programs only.  
-1\. Disconnect all FTDI devices.  
-2\. Download and run the D2xxHelper installer from [https://ftdichip.com/drivers/d2xx-drivers/](https://ftdichip.com/drivers/d2xx-drivers/)
-3\. Reboot.  
-4\. Reconnect the FTDI devices.
+1. Disconnect all FTDI devices.  
+2. Download and run the D2xxHelper installer from [https://ftdichip.com/drivers/d2xx-drivers/](https://ftdichip.com/drivers/d2xx-drivers/).  
+3. Reboot.  
+4. Reconnect the FTDI devices.

--- a/pages/09.plugins/disable-apple-serial-vcp-driver/default.v4_ca.md
+++ b/pages/09.plugins/disable-apple-serial-vcp-driver/default.v4_ca.md
@@ -59,7 +59,7 @@ Bloc amb D2xxHelper (OS X 10.9 i posteriors)
 Nota: aquest és l'únic mètode no temporal que funciona en el **10.11 El Capitan**.
 
 FTDI proporciona una extensió del nucli signada (D2xxHelper.kext) que no conté cap codi però actua per evitar que OS X coincideixi amb un xip FTDI (amb el proveïdor estàndard i els identificadors de producte) amb un controlador VCP, ja sigui d'Apple o de FTDI. Això deixa el dispositiu sense reclamar, i només disponible per als programes D2XX.  
-1\. Desconnecta tots els dispositius FTDI.  
-2\. Baixeu i executeu l'instal·lador D2xxHelper des de [https://ftdichip.com/drivers/d2xx-drivers/](https://ftdichip.com/drivers/d2xx-drivers/)
-3\. Reinicia.
-  4\. Reconnecta els dispositius FTDI.
+1. Desconnecta tots els dispositius FTDI.  
+2. Baixeu i executeu l'instal·lador D2xxHelper des de [https://ftdichip.com/drivers/d2xx-drivers/](https://ftdichip.com/drivers/d2xx-drivers/).  
+3. Reinicia.  
+4. Reconnecta els dispositius FTDI.

--- a/pages/09.plugins/disable-apple-serial-vcp-driver/default.v4_de.md
+++ b/pages/09.plugins/disable-apple-serial-vcp-driver/default.v4_de.md
@@ -55,7 +55,7 @@ Die Befehle kextunload und kextload können in jedem Verzeichnis ausgeführt wer
 Hinweis: Dies ist die einzige nicht temporäre Methode, die unter **10.11 El Capitan** funktioniert.
 
 FTDI stellt eine signierte Kernel-Erweiterung (D2xxHelper.kext) bereit, die keinen Code enthält, aber verhindert, dass OS Dadurch bleibt das Gerät unbeansprucht und steht nur für D2XX-Programme zur Verfügung.
-1\. Trennen Sie alle FTDI-Geräte.
-2\. Laden Sie das D2xxHelper-Installationsprogramm von [https://ftdichip.com/drivers/d2xx-drivers/](https://ftdichip.com/drivers/d2xx-drivers/) herunter und führen Sie es aus.
-3\. Neustart.
-4\. Schließen Sie die FTDI-Geräte erneut an.
+1. Trennen Sie alle FTDI-Geräte.  
+2. Laden Sie das D2xxHelper-Installationsprogramm von [https://ftdichip.com/drivers/d2xx-drivers/](https://ftdichip.com/drivers/d2xx-drivers/) herunter und führen Sie es aus.  
+3. Neustart.  
+4. Schließen Sie die FTDI-Geräte erneut an.

--- a/pages/09.plugins/disable-apple-serial-vcp-driver/default.v4_de.md
+++ b/pages/09.plugins/disable-apple-serial-vcp-driver/default.v4_de.md
@@ -11,7 +11,7 @@ Ein VCP-Treiber für die meisten FTDI-USB-zu-Seriell-Konverter wird als Teil des
 
 ### Deaktivieren durch Umbenennen (nur OS X 10.9 und 10.10)
 
-Hinweis: Diese Methode funktioniert **nur auf 10.9 Mavericks und 10.10 Yosemite.**
+Hinweis: Diese Methode funktioniert **nur auf 10.9 Mavericks und 10.10 Yosemite.**  
 
 Starten Sie eine Terminalsitzung (Gehe zu > Anwendungen > Dienstprogramme > Terminal) und kopieren Sie den folgenden Text und fügen Sie ihn in die Eingabeaufforderung ein:
 
@@ -21,7 +21,7 @@ sudo mv AppleUSBFTDI.kext AppleUSBFTDI.disabled
 sudo touch /System/Library/Extensions
 ```
 
-dann neu starten.
+dann neu starten.  
 Um VCP wieder zu aktivieren, benennen Sie AppleUSBFTDI.disabled wieder in AppleUSBFTDI.kext um
 
 ```
@@ -34,7 +34,7 @@ dann neu starten.
 
 ### Vorübergehend entladen (alle Versionen von OS X)
 
-Hinweis: Diese Methode funktioniert auf allen Versionen von OS X.
+Hinweis: Diese Methode funktioniert auf allen Versionen von OS X.  
 
 Es ist möglich, Apples VCP für die aktuelle Sitzung, also bis zum nächsten Neustart, zu entladen:
 
@@ -54,7 +54,7 @@ Die Befehle kextunload und kextload können in jedem Verzeichnis ausgeführt wer
 
 Hinweis: Dies ist die einzige nicht temporäre Methode, die unter **10.11 El Capitan** funktioniert.
 
-FTDI stellt eine signierte Kernel-Erweiterung (D2xxHelper.kext) bereit, die keinen Code enthält, aber verhindert, dass OS Dadurch bleibt das Gerät unbeansprucht und steht nur für D2XX-Programme zur Verfügung.
+FTDI stellt eine signierte Kernel-Erweiterung (D2xxHelper.kext) bereit, die keinen Code enthält, aber verhindert, dass OS Dadurch bleibt das Gerät unbeansprucht und steht nur für D2XX-Programme zur Verfügung.  
 1. Trennen Sie alle FTDI-Geräte.  
 2. Laden Sie das D2xxHelper-Installationsprogramm von [https://ftdichip.com/drivers/d2xx-drivers/](https://ftdichip.com/drivers/d2xx-drivers/) herunter und führen Sie es aus.  
 3. Neustart.  

--- a/pages/10.fixture-definition-editor/02.physical/default.v4_de.md
+++ b/pages/10.fixture-definition-editor/02.physical/default.v4_de.md
@@ -3,7 +3,7 @@ title: Physisch
 date: '05:31 22-08-2023'
 ---
 
-Dies ist der Abschnitt, in dem die _globalen_ physischen Informationen des Geräts bereitgestellt werden.
+Dies ist der Abschnitt, in dem die _globalen_ physischen Informationen des Geräts bereitgestellt werden.  
 In jedem Modus ist auch ein identischer Abschnitt vorhanden, falls das Gerät die Änderung seiner physikalischen Eigenschaften (z. B. Schwenk-/Neigebereich) je nach Modus zulässt. In diesem Fall können die globalen physischen Informationen durch physische Informationen pro Modus überschrieben werden.
 
 ![](../fixture_editor_physical.png)

--- a/pages/10.fixture-definition-editor/04.modes/default.v4_de.md
+++ b/pages/10.fixture-definition-editor/04.modes/default.v4_de.md
@@ -68,6 +68,6 @@ Das Bearbeiten eines Kopfes ist sehr einfach: Setzen Sie ein Häkchen bei jedem 
 
 ## Registerkarte „Physisch“.
 
-Diese Registerkarte ist identisch mit der _globalen_ [physischen Registerkarte](/fixture-definition-editor/physical), die sich in den Hauptfenstern des Fixture-Editors befindet.
+Diese Registerkarte ist identisch mit der _globalen_ [physischen Registerkarte](/fixture-definition-editor/physical), die sich in den Hauptfenstern des Fixture-Editors befindet.  
 Der einzige Unterschied besteht darin, dass Sie hier auswählen können, ob der Modus, den Sie bearbeiten, dieselben oder unterschiedliche physische Informationen enthält.
 Lassen Sie im ersten Fall einfach die Option **„Globale Einstellungen verwenden“** aktiviert. Wenn der Modus unterschiedliche Eigenschaften verfügbar macht, aktivieren Sie die Option **Globale Einstellungen überschreiben** und geben Sie alle erforderlichen Informationen ein.

--- a/pages/10.fixture-definition-editor/05.aliases/default.v4_de.md
+++ b/pages/10.fixture-definition-editor/05.aliases/default.v4_de.md
@@ -3,9 +3,9 @@ title: Alias
 date: '07:10 22-08-2023'
 ---
 
-Auf dieser Registerkarte ist es möglich, die Ersetzungsregeln zu definieren, die durch als „Alias“ voreingestellte Funktionen ausgelöst werden.
-Machen wir ein Beispiel. Ein Gerät verfügt über Kanal 5 mit der Bezeichnung „Effekte“, der das Verhalten von Kanal 6 steuert. Kanal 5 verfügt über zwei Funktionen: „Geschwindigkeit auf Kanal 6“ und „Tonempfindlichkeit auf Kanal 6“. Letztere sind auf die Voreinstellung „Alias“ eingestellt. Wenn der DMX-Wert von Kanal 5 standardmäßig 0 ist, fungiert Kanal 6 als Geschwindigkeitssteuerung. Wenn der DMX-Wert von Kanal 5 in die Funktion „Tonempfindlichkeit“ wechselt, wird Kanal 6 zur Einstellung der Tonempfindlichkeit.
-Um diesen Fall zu bewältigen, müssen Sie zwei Kanäle definieren: „Geschwindigkeit“ und „Schallempfindlichkeit“. Fügen Sie im Fixture-Modus nur „Speed“ hinzu, da dies das Standardverhalten ist, wenn der DMX-Wert von Kanal 5 gleich 0 ist.
+Auf dieser Registerkarte ist es möglich, die Ersetzungsregeln zu definieren, die durch als „Alias“ voreingestellte Funktionen ausgelöst werden.  
+Machen wir ein Beispiel. Ein Gerät verfügt über Kanal 5 mit der Bezeichnung „Effekte“, der das Verhalten von Kanal 6 steuert. Kanal 5 verfügt über zwei Funktionen: „Geschwindigkeit auf Kanal 6“ und „Tonempfindlichkeit auf Kanal 6“. Letztere sind auf die Voreinstellung „Alias“ eingestellt. Wenn der DMX-Wert von Kanal 5 standardmäßig 0 ist, fungiert Kanal 6 als Geschwindigkeitssteuerung. Wenn der DMX-Wert von Kanal 5 in die Funktion „Tonempfindlichkeit“ wechselt, wird Kanal 6 zur Einstellung der Tonempfindlichkeit.  
+Um diesen Fall zu bewältigen, müssen Sie zwei Kanäle definieren: „Geschwindigkeit“ und „Schallempfindlichkeit“. Fügen Sie im Fixture-Modus nur „Speed“ hinzu, da dies das Standardverhalten ist, wenn der DMX-Wert von Kanal 5 gleich 0 ist.  
 Dann müssen Sie nur noch einen Alias ​​definieren: den, der den Standardkanal „Geschwindigkeit“ durch „Tonempfindlichkeit“ ersetzt. QLC+ weiß dann, was zu tun ist, wenn der DMX-Wert von Kanal 5 den Alias ​​betritt oder verlässt.
 
 ![](../fixture_editor_aliases.png)

--- a/pages/11.advanced/01.web-interface/default.v4_de.md
+++ b/pages/11.advanced/01.web-interface/default.v4_de.md
@@ -3,18 +3,18 @@ title: 'Web Interface'
 date: '08:15 22-08-2023'
 ---
 
-BStandardmäßig enthält QLC+ einen nativen Webserver, um einige der Softwarefunktionen in herkömmlichen Webbrowsern verfügbar zu machen.
-Dies ist sehr praktisch, wenn Sie QLC+ auf einem Gerät ohne Display (Headless-System) ausführen müssen, um entweder eigenständig zu arbeiten oder um es fernzusteuern.
+Standardmäßig enthält QLC+ einen nativen Webserver, um einige der Softwarefunktionen in herkömmlichen Webbrowsern verfügbar zu machen.  
+Dies ist sehr praktisch, wenn Sie QLC+ auf einem Gerät ohne Display (Headless-System) ausführen müssen, um entweder eigenständig zu arbeiten oder um es fernzusteuern.  
 Die Weboberfläche ist standardmäßig nicht aktiviert, kann aber einfach durch Ausführen von QLC+ mit der Option „-w“ oder „--web“ aktiviert werden. Weitere Informationen dazu finden Sie auf der Seite [Befehlszeilenparameter](../command-line-parameters) dieser Dokumentation.
 
-Auf die Weboberfläche kann über jeden modernen Webbrowser zugegriffen werden, der auf jedem Gerät läuft, beispielsweise einem Computer, einem Tablet oder einem Smartphone. Ihr Browser muss die Web-Sockets-Technologie unterstützen, um mit QLC+ kommunizieren zu können. Es wird empfohlen, Google Chrome zu verwenden.
-Es ist auch möglich, benutzerdefinierte Webseiten zu entwerfen und über die Web-API auf QLC+-Funktionen zuzugreifen, bei denen es sich im Wesentlichen um auf eine bestimmte Weise formatierte Zeichenfolgen handelt, die über einen Websocket an QLC+ gesendet werden.
+Auf die Weboberfläche kann über jeden modernen Webbrowser zugegriffen werden, der auf jedem Gerät läuft, beispielsweise einem Computer, einem Tablet oder einem Smartphone. Ihr Browser muss die Web-Sockets-Technologie unterstützen, um mit QLC+ kommunizieren zu können. Es wird empfohlen, Google Chrome zu verwenden.  
+Es ist auch möglich, benutzerdefinierte Webseiten zu entwerfen und über die Web-API auf QLC+-Funktionen zuzugreifen, bei denen es sich im Wesentlichen um auf eine bestimmte Weise formatierte Zeichenfolgen handelt, die über einen Websocket an QLC+ gesendet werden.  
 Eine Testseite mit den verfügbaren APIs finden Sie [hier](https://www.qlcplus.org/Test_Web_API.html).
 
-Um auf die QLC+-Weboberfläche zuzugreifen, stellen Sie einfach eine Verbindung zu dieser Adresse her:
-**http://\[IP-Adresse\]:9999**
+Um auf die QLC+-Weboberfläche zuzugreifen, stellen Sie einfach eine Verbindung zu dieser Adresse her:  
+**http://\[IP-Adresse\]:9999**  
 
-Dabei ist \[IP-Adresse\] die IP-Adresse des Geräts, auf das Sie über das Internet zugreifen möchten. Beispiel: http://192.168.0.100:9999
+Dabei ist \[IP-Adresse\] die IP-Adresse des Geräts, auf das Sie über das Internet zugreifen möchten. Beispiel: http://192.168.0.100:9999  
 Die Weboberfläche besteht aus drei Seiten:
 
 * Virtuelle Konsole
@@ -24,22 +24,22 @@ Die Weboberfläche besteht aus drei Seiten:
 Seite „Virtuelle Konsole“.
 --------------------
 
-Diese Seite wird standardmäßig beim Zugriff auf die Webschnittstellenadresse angezeigt und stellt die virtuelle QLC+-Konsole dar.
-Wenn ein Projekt geladen ist, werden auf dieser Seite die zuvor mit QLC+ erstellten Widgets angezeigt, andernfalls wird nur eine leere Seite angezeigt.
-Es ist möglich, ein Projekt mit der Schaltfläche **Projekt laden** in der oberen linken Ecke der Seite zu laden. Es erscheint ein Fenster, in dem Sie eine Datei von dem Gerät auswählen können, mit dem Sie das Gerät steuern, auf dem QLC+ ausgeführt wird.
-Die Projektdatei wird über das Web übertragen und von QLC+ geladen.
+Diese Seite wird standardmäßig beim Zugriff auf die Webschnittstellenadresse angezeigt und stellt die virtuelle QLC+-Konsole dar.  
+Wenn ein Projekt geladen ist, werden auf dieser Seite die zuvor mit QLC+ erstellten Widgets angezeigt, andernfalls wird nur eine leere Seite angezeigt.  
+Es ist möglich, ein Projekt mit der Schaltfläche **Projekt laden** in der oberen linken Ecke der Seite zu laden. Es erscheint ein Fenster, in dem Sie eine Datei von dem Gerät auswählen können, mit dem Sie das Gerät steuern, auf dem QLC+ ausgeführt wird.  
+Die Projektdatei wird über das Web übertragen und von QLC+ geladen.  
 Um auf die QLC+-Konfigurationsseite zuzugreifen, klicken Sie einfach auf die Schaltfläche **Konfiguration**.
 
 Einfache Schreibtischseite
 ----------------
 
-Diese Seite ist eine vereinfachte Version des Simple Desk, den Sie in der QLC+-Desktopversion finden. Es zeigt DMX-Universen nach Seiten unterteilt an, wobei jede Seite 32 Kanäle anzeigt. Sie können mit den Pfeiltasten nach links/rechts zwischen den Seiten wechseln und mit dem Dropdown-Menü oben rechts auf der Seite das aktuell angezeigte Universum auswählen.
-Es ist auch möglich, ein Universum auf einmal zurückzusetzen, indem Sie die Reset-Taste (graues X) drücken.
+Diese Seite ist eine vereinfachte Version des Simple Desk, den Sie in der QLC+-Desktopversion finden. Es zeigt DMX-Universen nach Seiten unterteilt an, wobei jede Seite 32 Kanäle anzeigt. Sie können mit den Pfeiltasten nach links/rechts zwischen den Seiten wechseln und mit dem Dropdown-Menü oben rechts auf der Seite das aktuell angezeigte Universum auswählen.  
+Es ist auch möglich, ein Universum auf einmal zurückzusetzen, indem Sie die Reset-Taste (graues X) drücken.  
 
 ### DMX-Tastatur
 
-Wenn Sie in der oberen Leiste von Simple Desk auf die Schaltfläche „DMX-Tastatur“ klicken, können Sie zu einer neuen Seite springen, auf der eine herkömmliche DMX-Tastatur angezeigt wird.
-Das Tastenfeld ist nützlich, um eine Reihe von Kanalwerten mit einem einzigen Befehl festzulegen. Nachfolgend finden Sie eine Tabelle mit Erläuterungen zu den Tastenbefehlen, die Sie auf der rechten Seite des Pads finden.
+Wenn Sie in der oberen Leiste von Simple Desk auf die Schaltfläche „DMX-Tastatur“ klicken, können Sie zu einer neuen Seite springen, auf der eine herkömmliche DMX-Tastatur angezeigt wird.  
+Das Tastenfeld ist nützlich, um eine Reihe von Kanalwerten mit einem einzigen Befehl festzulegen. Nachfolgend finden Sie eine Tabelle mit Erläuterungen zu den Tastenbefehlen, die Sie auf der rechten Seite des Pads finden.  
 
 
 |     |     |
@@ -65,18 +65,18 @@ Konfigurationsseite
 
 Auf dieser Seite können Sie die QLC+-Konfiguration aus der Ferne festlegen, die in vier Bereiche unterteilt ist:
 
-* **Universenkonfiguration**: Ermöglicht das Festlegen der Eingänge, Ausgänge, Rückmeldungen, Profile und des Passthrough-Modus für jedes QLC+-Universum. Dies ist im Grunde die gleiche Funktionalität wie das QLC+-Eingabe-/Ausgabefeld.
-    Da ein QLC+-Projekt auch die I/O-Informationen enthält, müssen Sie es auf dieser Seite höchstwahrscheinlich nicht manuell konfigurieren, sondern einfach überprüfen, ob alles korrekt ist.
+* **Universenkonfiguration**: Ermöglicht das Festlegen der Eingänge, Ausgänge, Rückmeldungen, Profile und des Passthrough-Modus für jedes QLC+-Universum. Dies ist im Grunde die gleiche Funktionalität wie das QLC+-Eingabe-/Ausgabefeld.  
+    Da ein QLC+-Projekt auch die I/O-Informationen enthält, müssen Sie es auf dieser Seite höchstwahrscheinlich nicht manuell konfigurieren, sondern einfach überprüfen, ob alles korrekt ist.  
 
-* **Audiokonfiguration**: Ermöglicht die Auswahl der Audiogeräte, die für die Audiowiedergabe oder Audioeingabe verwendet werden.
+* **Audiokonfiguration**: Ermöglicht die Auswahl der Audiogeräte, die für die Audiowiedergabe oder Audioeingabe verwendet werden.  
 
-* **Vom Benutzer geladene Geräte**: Ermöglicht das Remote-Laden eines benutzerdefinierten Geräts auf QLC+.
-    Wenn Sie auf die Schaltfläche **Gerät laden** klicken, wird ein Fenster angezeigt, in dem Sie eine Datei von dem Gerät auswählen können, mit dem Sie das Gerät steuern, auf dem QLC+ ausgeführt wird.
-    Die Fixture-Datei wird über das Internet übertragen und von QLC+ geladen.
-    Beim Hinzufügen neuer benutzerdefinierter Geräte wird empfohlen, ein Projekt neu zu laden oder QLC+ auf dem Zielgerät neu zu starten.
+* **Vom Benutzer geladene Geräte**: Ermöglicht das Remote-Laden eines benutzerdefinierten Geräts auf QLC+.  
+    Wenn Sie auf die Schaltfläche **Gerät laden** klicken, wird ein Fenster angezeigt, in dem Sie eine Datei von dem Gerät auswählen können, mit dem Sie das Gerät steuern, auf dem QLC+ ausgeführt wird.  
+    Die Fixture-Datei wird über das Internet übertragen und von QLC+ geladen.  
+    Beim Hinzufügen neuer benutzerdefinierter Geräte wird empfohlen, ein Projekt neu zu laden oder QLC+ auf dem Zielgerät neu zu starten.  
 
-* **Autorisierte Benutzer**: Dieser Abschnitt ist nur verfügbar, wenn QLC+ mit der Option „-wa“ oder „--web-auth“ gestartet wird. Es ermöglicht eine grundlegende HTTP-Authentifizierung (kein HTTPS oder Zertifikate erforderlich).
-    Wenn Sie diese Funktion zum ersten Mal aktivieren, müssen Sie mindestens einen Administrator hinzufügen, andernfalls werden Sie beim Zugriff auf die Weboberfläche nicht nach einem Passwort gefragt.
+* **Autorisierte Benutzer**: Dieser Abschnitt ist nur verfügbar, wenn QLC+ mit der Option „-wa“ oder „--web-auth“ gestartet wird. Es ermöglicht eine grundlegende HTTP-Authentifizierung (kein HTTPS oder Zertifikate erforderlich).  
+    Wenn Sie diese Funktion zum ersten Mal aktivieren, müssen Sie mindestens einen Administrator hinzufügen, andernfalls werden Sie beim Zugriff auf die Weboberfläche nicht nach einem Passwort gefragt.  
     Benutzer können die folgenden Zugriffsebenen haben:
 
     * **Alles**: Dies ist die Zugriffsebene für Administratoren. Sie können auf alle Funktionen der Weboberfläche zugreifen und weitere authentifizierte Benutzer hinzufügen

--- a/pages/11.advanced/03.command-line-parameters/default.v4_de.md
+++ b/pages/11.advanced/03.command-line-parameters/default.v4_de.md
@@ -3,7 +3,7 @@ title: 'Befehlszeilenparameter'
 date: '08:19 22-08-2023'
 ---
 
-QLC+ unterstützt eine Reihe von Befehlszeilenparametern, um einige Funktionalitäten beim Start zu automatisieren/erweitern.
+QLC+ unterstützt eine Reihe von Befehlszeilenparametern, um einige Funktionalitäten beim Start zu automatisieren/erweitern.  
 Die Verwendung von Befehlszeilenparametern kann je nach verwendetem Betriebssystem schwierig sein:
 
 **Linux**: Öffnen Sie einfach ein Terminal und geben Sie „qlcplus“ gefolgt von den benötigten Parametern ein<br>

--- a/pages/11.advanced/04.parameters-tuning/default.v4_de.md
+++ b/pages/11.advanced/04.parameters-tuning/default.v4_de.md
@@ -3,7 +3,7 @@ title: 'Parameteroptimierung'
 date: '11:41 22-08-2023'
 ---
 
-In diesem Abschnitt wird erläutert, wie Sie einige QLC+-Parameter, die über die Benutzeroberfläche nicht verfügbar sind, manuell abrufen und anpassen können.
+In diesem Abschnitt wird erläutert, wie Sie einige QLC+-Parameter, die über die Benutzeroberfläche nicht verfügbar sind, manuell abrufen und anpassen können.  
 Denken Sie daran, dass es einen guten Grund dafür gibt, wenn Sie sie nicht über die Benutzeroberfläche ändern können.
 
 > **Warnung: Bearbeiten Sie die Konfigurationsdateien NICHT manuell, es sei denn, Sie wissen, was Sie tun. Jede falsch platzierte Änderung kann zu Programmabstürzen oder unangenehmer Instabilität führen.**
@@ -15,41 +15,41 @@ Denken Sie daran, dass es einen guten Grund dafür gibt, wenn Sie sie nicht übe
 Linux
 -----
 
-Die Konfigurationsdateien befinden sich im $HOME-Verzeichnis Ihres Benutzers im Ordner .config/qlcplus.
-Hier ist der Schnellbefehl, um von einem Terminal aus darauf zuzugreifen:
-`cd $HOME/.config/qlcplus`
+Die Konfigurationsdateien befinden sich im $HOME-Verzeichnis Ihres Benutzers im Ordner .config/qlcplus.  
+Hier ist der Schnellbefehl, um von einem Terminal aus darauf zuzugreifen:  
+`cd $HOME/.config/qlcplus`  
 Sie finden sowohl QLC+- als auch Fixture-Editor-Konfigurationsdateien.
 
 Windows
 -------
 
-Konfigurationsparameter werden in der Windows-Registrierung gespeichert.
-Um darauf zuzugreifen, führen Sie das Tool „regedit“ aus und suchen Sie nach dem Schlüssel mit dem Namen „qlcplus“.
+Konfigurationsparameter werden in der Windows-Registrierung gespeichert.  
+Um darauf zuzugreifen, führen Sie das Tool „regedit“ aus und suchen Sie nach dem Schlüssel mit dem Namen „qlcplus“.  
 Der Schlüssel, in dem die Benutzerkonfiguration gespeichert wird, wird benannt
 `Computer\HKEY_CURRENT_USER\Software\qlcplus\`
 
 macOS
 -------
 
-Konfigurationsdateien befinden sich im $HOME-Verzeichnis Ihres Benutzers im Ordner „Library/Preferences“, der von macOS standardmäßig ausgeblendet ist.
-Hier ist der Schnellbefehl, um von einem Terminal aus darauf zuzugreifen:
-`cd $HOME/Library/Preferences`
-Die QLC+-Konfigurationsdatei heißt „net.sf.Q Light Controller Plus.plist“, während die Konfigurationsdatei des Fixture-Editors „net.sf.Fixture Definition Editor.plist“ heißt.
+Konfigurationsdateien befinden sich im $HOME-Verzeichnis Ihres Benutzers im Ordner „Library/Preferences“, der von macOS standardmäßig ausgeblendet ist.  
+Hier ist der Schnellbefehl, um von einem Terminal aus darauf zuzugreifen:  
+`cd $HOME/Library/Preferences`  
+Die QLC+-Konfigurationsdatei heißt „net.sf.Q Light Controller Plus.plist“, während die Konfigurationsdatei des Fixture-Editors „net.sf.Fixture Definition Editor.plist“ heißt.  
 
-**Bitte beachten Sie, dass die Einstellungen zwischengespeichert werden!**
-Grundsätzlich lädt macOS beim Booten alle Plist-Dateien im Speicher, und wenn Sie sie manuell ändern, werden die Änderungen ignoriert. Schlimmer noch: Die Dateien werden regelmäßig aktualisiert, sodass Ihre Änderungen überschrieben werden.
-Die Lösung besteht darin, nach dem Ändern einer .plist-Datei ein Terminal zu öffnen und Folgendes einzugeben:
-`killall -u yourusername cfprefsd`
+**Bitte beachten Sie, dass die Einstellungen zwischengespeichert werden!**  
+Grundsätzlich lädt macOS beim Booten alle Plist-Dateien im Speicher, und wenn Sie sie manuell ändern, werden die Änderungen ignoriert. Schlimmer noch: Die Dateien werden regelmäßig aktualisiert, sodass Ihre Änderungen überschrieben werden.  
+Die Lösung besteht darin, nach dem Ändern einer .plist-Datei ein Terminal zu öffnen und Folgendes einzugeben:  
+`killall -u yourusername cfprefsd`  
 Dabei ist „IhrBenutzername“ der Name des Benutzers, den Sie für den Zugriff auf Ihren Mac verwenden. Der Befehl zwingt macOS dazu, die Einstellungen einschließlich Ihrer Änderungen neu zu laden.
 
 ## Konfiguration zurücksetzen
 <hr>
 
-Manchmal kann es notwendig sein, die QLC+-Konfiguration zurückzusetzen und QLC+ in den Zustand „Werkseinstellungen“ zu versetzen.
+Manchmal kann es notwendig sein, die QLC+-Konfiguration zurückzusetzen und QLC+ in den Zustand „Werkseinstellungen“ zu versetzen.  
 Suchen Sie dazu die Konfiguration wie im ersten Absatz beschrieben und gehen Sie dann wie folgt vor:
 
-* Unter Linux und OSX verwenden Sie den Befehl „rm 'filename‘“, um die Konfigurationsdatei zu löschen
-* Unter Windows löschen Sie den gesamten „qlcplus“-SCHLÜSSEL mit regedit
+* Unter Linux und OSX verwenden Sie den Befehl „rm 'filename‘“, um die Konfigurationsdatei zu löschen.
+* Unter Windows löschen Sie den gesamten „qlcplus“-SCHLÜSSEL mit regedit.
 
 ## Parametersyntax
 <hr>

--- a/pages/11.advanced/05.custom-ui-style/default.v4.md
+++ b/pages/11.advanced/05.custom-ui-style/default.v4.md
@@ -35,7 +35,7 @@ At the moment, supported section keywords are:
 
 The section content must have a CSS syntax. If you're comfortable with web designing, you should find the creation of this file very easy!  
 Since the style file is strictly related to the inner Qt objects, you might want to read the following articles to find out the elements' names and the additional CSS properties the Qt team added to the default CSS syntax.  
-[Qt Style Sheets](https://doc.qt.io/archives/qt-5.15/stylesheet-syntax.html)
+[Qt Style Sheets](https://doc.qt.io/archives/qt-5.15/stylesheet-syntax.html)  
 [Qt Style Sheets Examples](https://doc.qt.io/archives/qt-4.8/stylesheet-examples.html)  
 It is up to your imagination how you prefer to customize the QLC+ GUI appearance! If you find a style worth sharing, don't forget to send in your contribution by posting it online in the [QLC+ forum](https://www.qlcplus.org/forum/viewforum.php?f=5)
 

--- a/pages/11.advanced/05.custom-ui-style/default.v4_ca.md
+++ b/pages/11.advanced/05.custom-ui-style/default.v4_ca.md
@@ -18,7 +18,7 @@ El fitxer d'estil també s'ha de col·locar en un camí específic que és:
 
 El fitxer d'estil ha de tenir una sintaxi CSS. Si esteu còmode amb el disseny web, heu de trobar la creació d'aquest fitxer molt fàcil!  
 Atès que el fitxer d'estil està estrictament relacionat amb els objectes interiors de les Qt, és possible que vulgueu llegir els articles següents per a esbrinar els noms dels elements i les propietats CSS addicionals que l'equip de les Qt ha afegit a la sintaxi CSS predeterminada.  
-[Fulls d'estil de les Qt](https://doc.qt.io/archives/qt-5.15/stylesheet-syntax.html)
+[Fulls d'estil de les Qt](https://doc.qt.io/archives/qt-5.15/stylesheet-syntax.html)  
 [Fulls d'estil de les Qt Exemples](https://doc.qt.io/archives/qt-4.8/stylesheet-examples.html)  
 Depèn de la teva imaginació com prefereixis personalitzar l'aparença de la IGU QLC+! Si trobeu un estil digne de compartir, no oblideu enviar la vostra contribució publicant-lo en línia al [Fòrum QLC+](https://www.qlcplus.org/forum/viewforum.php?f=5)
 

--- a/pages/11.advanced/05.custom-ui-style/default.v4_de.md
+++ b/pages/11.advanced/05.custom-ui-style/default.v4_de.md
@@ -3,22 +3,22 @@ title: 'Benutzerdefinierter UI-Stil'
 date: '11:59 22-08-2023'
 ---
 
-Ab Version 4.5.0 kann QLC+ eine benutzerdefinierte Datei lesen, um das Erscheinungsbild der GUI auf sehr zugängliche Weise zu ändern.
+Ab Version 4.5.0 kann QLC+ eine benutzerdefinierte Datei lesen, um das Erscheinungsbild der GUI auf sehr zugängliche Weise zu ändern.  
 Wenn keine Datei gefunden wird, startet QLC+ mit dem Standardstil.
 
 Die Theme-Stildatei
 -------------------
 
-Der Dateiname ist in QLC+ fest codiert und muss lauten: `qlcplusStyle.qss`.
-Die Stildatei muss außerdem in einem bestimmten Pfad abgelegt werden:
+Der Dateiname ist in QLC+ fest codiert und muss lauten: `qlcplusStyle.qss`.  
+Die Stildatei muss außerdem in einem bestimmten Pfad abgelegt werden:  
 
 * **Linux**: `$HOME/.qlcplus`
 * **Windows**: „C:\\Benutzer\{Benutzername}\QLC+“.
 * **OSX**: `$HOME/Library/Application\\ Support/QLC+`
 
-Die Theme-Datei ist in Abschnitte unterteilt. Jeder Abschnitt stellt die UI-Elemente dar, die beim Ausführen von QLC+ geändert werden. Unveränderte Abschnitte können weggelassen werden.
-Abschnitte beginnen mit einer Reihe von „===“-Zeichen und dem Abschnittsnamen.
-Derzeit werden folgende Abschnittsschlüsselwörter unterstützt:
+Die Theme-Datei ist in Abschnitte unterteilt. Jeder Abschnitt stellt die UI-Elemente dar, die beim Ausführen von QLC+ geändert werden. Unveränderte Abschnitte können weggelassen werden.  
+Abschnitte beginnen mit einer Reihe von „===“-Zeichen und dem Abschnittsnamen.  
+Derzeit werden folgende Abschnittsschlüsselwörter unterstützt:  
 ```
 ============== MAIN
 ============== SIMPLE_DESK_NONE
@@ -33,10 +33,10 @@ Derzeit werden folgende Abschnittsschlüsselwörter unterstützt:
 ============== CONSOLE_CHANNEL_COMMON
 ```
 
-Der Abschnittsinhalt muss eine CSS-Syntax haben. Wenn Sie sich mit Webdesign auskennen, dürfte Ihnen die Erstellung dieser Datei sehr leicht fallen!
-Da die Stildatei eng mit den inneren Qt-Objekten verknüpft ist, möchten Sie möglicherweise die folgenden Artikel lesen, um die Namen der Elemente und die zusätzlichen CSS-Eigenschaften herauszufinden, die das Qt-Team der Standard-CSS-Syntax hinzugefügt hat.
-[Qt-Stylesheets](https://doc.qt.io/archives/qt-5.15/stylesheet-syntax.html)
-[Beispiele für Qt-Stylesheets](https://doc.qt.io/archives/qt-4.8/stylesheet-examples.html)
+Der Abschnittsinhalt muss eine CSS-Syntax haben. Wenn Sie sich mit Webdesign auskennen, dürfte Ihnen die Erstellung dieser Datei sehr leicht fallen!  
+Da die Stildatei eng mit den inneren Qt-Objekten verknüpft ist, möchten Sie möglicherweise die folgenden Artikel lesen, um die Namen der Elemente und die zusätzlichen CSS-Eigenschaften herauszufinden, die das Qt-Team der Standard-CSS-Syntax hinzugefügt hat.  
+[Qt-Stylesheets](https://doc.qt.io/archives/qt-5.15/stylesheet-syntax.html)  
+[Beispiele für Qt-Stylesheets](https://doc.qt.io/archives/qt-4.8/stylesheet-examples.html)  
 Es bleibt Ihrer Fantasie überlassen, wie Sie das Erscheinungsbild der QLC+-GUI am liebsten anpassen möchten! Wenn Sie einen Stil finden, der es wert ist, geteilt zu werden, vergessen Sie nicht, Ihren Beitrag einzusenden, indem Sie ihn online im [QLC+-Forum](https://www.qlcplus.org/forum/viewforum.php?f=5) veröffentlichen.
 
 Bitte beachten Sie: Nicht alle Stile können über das Stylesheet geändert werden, da sie in C++ fest codiert sind.
@@ -44,7 +44,7 @@ Bitte beachten Sie: Nicht alle Stile können über das Stylesheet geändert werd
 Beispiel für den dunkelblauen QLC+-Stil
 --------------
 
-Um Ihnen ein Beispiel dafür zu geben, wie einfach dieser Vorgang ist, finden Sie hier einen bläulich-dunklen Stil für QLC+.
+Um Ihnen ein Beispiel dafür zu geben, wie einfach dieser Vorgang ist, finden Sie hier einen bläulich-dunklen Stil für QLC+.  
 Wenn Sie die folgenden Zeilen wie oben erläutert an der richtigen Stelle in „qlcplusStyle.qss“ kopieren, werden Sie beim nächsten Start sehen, dass sie auf QLC+ angewendet werden.
 ```
 ============== MAIN


### PR DESCRIPTION
While working on #73 (d15731516fa4e044d05fdfb01c614c660e38c411) und #85 (5143cc1edb2c76c6795bd4cf2e12b5246f6f079f), I removed many spaces at the end of lines without considering that these force a line break/newline in Markdown and are actually used to structure the text.

In this PR, I tried to restore these newlines in order to standardise the layout of the text in all translations.
I apologise for these unnecessary changes.