### PR TITLE
Fix broken internal links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ## Introduction
 Welcome to the official documentation repository for [qlcplus](https://www.qlcplus.org/)!
 
-The [docs.qlcplus.org](https://docs.qlcplus.org/) website uses the [Grav](https://getgrav.org/) content management system (CMS) and Learn2 with Git Sync plugin. This helps us to collaboratively edit our Markdown-based documentation. When changes are made to this repo the website automatically reflects the changes.
+The [docs.qlcplus.org](https://docs.qlcplus.org/) website uses the [Grav](https://getgrav.org/) content management system (CMS) and Learn2 with Git Sync plugin. This helps us to collaboratively edit our Markdown-based documentation. When changes are made to this repository, the website automatically reflects the changes.
 
 ## Contributing
 
@@ -98,14 +98,15 @@ Engage with the QLC+ community in the [forums](https://www.qlcplus.org/forum/) o
 By contributing to the documentation, you're not only helping yourself but also supporting the QLC+ community. Together, we can create a comprehensive and reliable resource for lighting enthusiasts using QLC+.
 
 ---
-<p align="center" xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/"><a property="dct:title" rel="cc:attributionURL" href="https://docs.qlcplus.org">QLC+ Offiical Documentation</a> by <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://qlcplus.org">Massimo Callegari</a> is marked with <a href="https://creativecommons.org/publicdomain/zero/1.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC0 1.0 Universal<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/zero.svg?ref=chooser-v1" alt=""></a></p>
-
+<p align="center" xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/"><a property="dct:title" rel="cc:attributionURL" href="https://docs.qlcplus.org">QLC+ Official Documentation</a> by <a rel="cc:attributionURL dct:creator" property="cc:attributionName" href="https://qlcplus.org">Massimo Callegari</a> is marked with <a href="https://creativecommons.org/publicdomain/zero/1.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC0 1.0 Universal<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1" alt=""><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/zero.svg?ref=chooser-v1" alt=""></a></p>
 
 <p align="center">
     <a href="https://www.instagram.com/qlcplus/" alt="Instagram">
         <img src="https://img.shields.io/badge/Instagram-%23E4405F.svg?style=flat&logo=Instagram&logoColor=white" /></a>
-    <a href="https://www.youtube.com/watch?v=I9bccwcYQpM&" alt="YouTube">
-        <img src="https://img.shields.io/badge/YouTube-%23FF0000.svg?style=flat&logo=YouTube&logoColor=white" /></a>
+    <a href="https://www.youtube.com/playlist?list=PLHT-wIriuitDiW4A9oKSDr__Z_jcmMVdi" alt="YouTube (v4)">
+        <img src="https://img.shields.io/badge/YouTube%20(v4)-%23FF0000.svg?style=flat&logo=YouTube&logoColor=white" /></a>
+    <a href="https://www.youtube.com/playlist?list=PLHT-wIriuitBQo0DKX9YgWVmS6LsEErE_" alt="YouTube (v5)">
+        <img src="https://img.shields.io/badge/YouTube%20(v5)-%23FF0000.svg?style=flat&logo=YouTube&logoColor=white" /></a>
     <a href="https://www.facebook.com/qlcplus" alt="Facebook">
         <img src="https://img.shields.io/badge/Facebook-%231877F2.svg?style=flat&logo=Facebook&logoColor=white" /></a>
 </p>

--- a/pages/03.fixtures-and-functions/01.universe-view/docs.v5.md
+++ b/pages/03.fixtures-and-functions/01.universe-view/docs.v5.md
@@ -12,7 +12,7 @@ exactly which channels each fixture occupies, spotting gaps or overlaps, and
 re-addressing fixtures.
 
 It is one of the four views available from the toolbar at the top of the
-[Fixtures and Functions](FixturesAndFunctions.md) workspace. Use the **universe
+[Fixtures and Functions](/fixtures-and-functions) workspace. Use the **universe
 selector** in that toolbar to choose which universe you are looking at.
 
 ## The grid

--- a/pages/03.fixtures-and-functions/02.dmx-view/docs.v5.md
+++ b/pages/03.fixtures-and-functions/02.dmx-view/docs.v5.md
@@ -12,7 +12,7 @@ is the best view for checking what every channel is currently outputting and for
 setting a single channel by hand.
 
 It is one of the four views available from the toolbar at the top of the
-[Fixtures and Functions](FixturesAndFunctions.md) workspace. Use the **universe
+[Fixtures and Functions](/fixtures-and-functions) workspace. Use the **universe
 selector** in that toolbar to limit the view to one universe.
 
 ## The fixture panels

--- a/pages/03.fixtures-and-functions/03.2d-view/docs.v5.md
+++ b/pages/03.fixtures-and-functions/03.2d-view/docs.v5.md
@@ -11,7 +11,7 @@ see their colour and beam from the chosen point of view. It is the main view for
 arranging a rig spatially and for designing looks visually.
 
 It is one of the four views available from the toolbar at the top of the
-[Fixtures and Functions](FixturesAndFunctions.md) workspace.
+[Fixtures and Functions](/fixtures-and-functions) workspace.
 
 ## Moving around
 

--- a/pages/03.fixtures-and-functions/04.3d-view/docs.v5.md
+++ b/pages/03.fixtures-and-functions/04.3d-view/docs.v5.md
@@ -11,7 +11,7 @@ show and is useful for visualising beam angles, positions and looks as an
 audience would see them.
 
 It is one of the four views available from the toolbar at the top of the
-[Fixtures and Functions](FixturesAndFunctions.md) workspace.
+[Fixtures and Functions](/fixtures-and-functions) workspace.
 
 > **Note:** The 3D View requires a system capable of the necessary graphics
 > rendering. On systems that don't support it, a notice is shown in place of the

--- a/pages/03.fixtures-and-functions/05.fixture-browser/docs.v5.md
+++ b/pages/03.fixtures-and-functions/05.fixture-browser/docs.v5.md
@@ -8,7 +8,7 @@ taxonomy:
 
 The **Fixture Browser** is where you patch new fixtures into your project. Open
 it with the **Add Fixtures** button at the top of the left panel in the
-[Fixtures and Functions](FixturesAndFunctions.md) workspace.
+[Fixtures and Functions](/fixtures-and-functions) workspace.
 
 It lets you find a fixture definition in the library, set how it should be
 patched, and drag it into one of the views.

--- a/pages/03.fixtures-and-functions/06.fixture-group-manager/docs.v5.md
+++ b/pages/03.fixtures-and-functions/06.fixture-group-manager/docs.v5.md
@@ -10,7 +10,7 @@ The **Fixture Group Manager** lists all the fixtures in your project, organised
 by universe, and lets you create **fixture groups**, inspect and rename items,
 and edit fixture and channel properties. Open it with the **Fixture Groups**
 button in the left panel of the
-[Fixtures and Functions](FixturesAndFunctions.md) workspace.
+[Fixtures and Functions](/fixtures-and-functions) workspace.
 
 ## The tree
 

--- a/pages/03.fixtures-and-functions/07.palette-manager/docs.v5.md
+++ b/pages/03.fixtures-and-functions/07.palette-manager/docs.v5.md
@@ -8,7 +8,7 @@ taxonomy:
 
 The **Palette Manager** lists the **palettes** in your project and lets you
 create, edit and delete them. Open it with the **Palettes** button in the left
-panel of the [Fixtures and Functions](FixturesAndFunctions.md) workspace.
+panel of the [Fixtures and Functions](/fixtures-and-functions) workspace.
 
 A palette is a saved, reusable value of a particular kind — an intensity level,
 a colour, a pan/tilt position, or a 3D position — that you can apply to fixtures

--- a/pages/05.function-manager/01.scene-editor/default.v5.md
+++ b/pages/05.function-manager/01.scene-editor/default.v5.md
@@ -51,4 +51,4 @@ in the time editor.
 
 > When a scene is part of a **Sequence**, it is edited through the Sequence
 > Editor's *Fixtures* tab rather than on its own. See
-> [Sequence Editor](SequenceEditor.md).
+> [Sequence Editor](../sequence-editor).

--- a/pages/08.virtual-console/01.button/default.v5.md
+++ b/pages/08.virtual-console/01.button/default.v5.md
@@ -3,7 +3,7 @@ title: Button
 date: '14:26 21-08-2023'
 ---
 
-A **Button** is the simplest [Virtual Console](VirtualConsole.md) widget: press
+A **Button** is the simplest [Virtual Console](/virtual-console) widget: press
 it to trigger a function. It's the building block of most consoles — one button
 per scene, chase or effect you want to fire.
 
@@ -32,7 +32,7 @@ from the button's settings.
 
 ## Tips
 
-* Combine buttons with a [Solo Frame](VCFrame.md) so that pressing one button
+* Combine buttons with a [Solo Frame](../solo-frame) so that pressing one button
   automatically stops the others — ideal for a row of mutually-exclusive looks.
 * Add an **external input** or **keyboard shortcut** (External controls tab) to
   fire the button from hardware or the keyboard.

--- a/pages/08.virtual-console/02.button-matrix/default.v4.md
+++ b/pages/08.virtual-console/02.button-matrix/default.v4.md
@@ -5,12 +5,12 @@ date: '14:30 21-08-2023'
 
 A **Button Matrix** is a quick way to create a whole **grid of buttons** at once,
 instead of adding them one by one. It belongs to the
-[Virtual Console](VirtualConsole.md) and is ideal for banks of scenes, colour
+[Virtual Console](/virtual-console) and is ideal for banks of scenes, colour
 buttons, or any set of looks you want laid out in a tidy block.
 
 A Button Matrix is not a separate kind of widget: it creates a
-[Frame](VCFrame.md) (or [Solo Frame](VCFrame.md)) filled with a grid of
-[Buttons](VCButton.md). Once created, each button is configured individually, and
+[Frame](../frame) (or [Solo Frame](../solo-frame)) filled with a grid of
+[Buttons](../button). Once created, each button is configured individually, and
 the surrounding frame behaves like any other frame.
 
 ## Creating one
@@ -25,16 +25,16 @@ setup** dialog appears, where you set:
   frame:
   * **Normal** — the buttons are independent.
   * **Solo** — only one button's function plays at a time; starting one stops the
-    others (see [Solo Frame](VCFrame.md)). Perfect for a grid of
+    others (see [Solo Frame](../solo-frame))). Perfect for a grid of
     mutually-exclusive looks such as a colour palette.
 
 Confirm to create the grid.
 
 ## After creation
 
-* Each cell is an ordinary [Button](VCButton.md) — select one in edit mode to
+* Each cell is an ordinary [Button](../button) — select one in edit mode to
   attach a function and set its behaviour.
-* The grid lives in a [Frame](VCFrame.md), so you can move, resize, label and
+* The grid lives in a [Frame](../frame), so you can move, resize, label and
   page the whole block together.
 
 ## Tips

--- a/pages/08.virtual-console/03.slider/default.v5.md
+++ b/pages/08.virtual-console/03.slider/default.v5.md
@@ -3,7 +3,7 @@ title: Slider
 date: '03:02 22-08-2023'
 ---
 
-A **Slider** is a fader in the [Virtual Console](VirtualConsole.md). Depending on
+A **Slider** is a fader in the [Virtual Console](/virtual-console). Depending on
 how it's configured it can control the level of a set of channels, act as a
 submaster, drive the Grand Master, or adjust an attribute of a function. The
 **Knob** widget is the same control drawn as a rotary dial instead of a fader.

--- a/pages/08.virtual-console/04.slider-matrix/default.v5.md
+++ b/pages/08.virtual-console/04.slider-matrix/default.v5.md
@@ -5,12 +5,12 @@ date: '03:07 22-08-2023'
 
 A **Slider Matrix** is a quick way to create a whole **bank of sliders** at once,
 instead of adding them one by one. It belongs to the
-[Virtual Console](VirtualConsole.md) and is ideal for channel-per-fader layouts,
+[Virtual Console](/virtual-console) and is ideal for channel-per-fader layouts,
 groups of submasters, or any row of faders you want laid out together.
 
 A Slider Matrix is not a separate kind of widget: it creates a
-[Frame](VCFrame.md) (or [Solo Frame](VCFrame.md)) filled with a grid of
-[Sliders](VCSlider.md). Once created, each slider is configured individually, and
+[Frame](../frame) (or [Solo Frame](../solo-frame)) filled with a grid of
+[Sliders](../slider). Once created, each slider is configured individually, and
 the surrounding frame behaves like any other frame.
 
 ## Creating one
@@ -26,15 +26,15 @@ setup** dialog appears, where you set:
   frame:
   * **Normal** — the sliders are independent (the usual choice).
   * **Solo** — only one slider's function plays at a time (see
-    [Solo Frame](VCFrame.md)).
+    [Solo Frame](/virtual-console)).
 
 Confirm to create the bank.
 
 ## After creation
 
-* Each cell is an ordinary [Slider](VCSlider.md) — select one in edit mode to set
+* Each cell is an ordinary [Slider](../slider) — select one in edit mode to set
   its mode (Level, Submaster, etc.) and the channels or attribute it controls.
-* The bank lives in a [Frame](VCFrame.md), so you can move, resize, label and
+* The bank lives in a [Frame](../frame), so you can move, resize, label and
   page the whole block together. Add a **Submaster** slider to the frame to put a
   master level over the whole bank.
 

--- a/pages/08.virtual-console/05.animation/default.v5.md
+++ b/pages/08.virtual-console/05.animation/default.v5.md
@@ -3,10 +3,10 @@ title: Animation
 date: '03:09 22-08-2023'
 ---
 
-An **Animation** widget plays and controls an [RGB Matrix](RGBMatrixEditor.md)
+An **Animation** widget plays and controls an [RGB Matrix](/function-manager/rgb-matrix-editor)
 function, letting you change its **colours** and switch its **pattern preset**
 live. It's the performance front-end for pixel/LED effects in the
-[Virtual Console](VirtualConsole.md).
+[Virtual Console](/virtual-console).
 
 Attach an RGB Matrix function by dragging it onto the widget or from the
 settings.

--- a/pages/08.virtual-console/06.speed-dial/default.v5.md
+++ b/pages/08.virtual-console/06.speed-dial/default.v5.md
@@ -7,7 +7,7 @@ media_order: speeddial.png
 A **Speed Dial** sets and adjusts the **timing** of functions live — the fade in,
 fade out and duration times. Use it to speed up or slow down chases and effects
 on the fly, often tapped in time with the music. It belongs to the
-[Virtual Console](VirtualConsole.md).
+[Virtual Console](/virtual-console).
 
 ## Settings
 

--- a/pages/08.virtual-console/07.xy-pad/default.v5.md
+++ b/pages/08.virtual-console/07.xy-pad/default.v5.md
@@ -6,7 +6,7 @@ media_order: 'xypad.png,xypad2.png,xypad-efx.png'
 
 An **XY Pad** is a two-axis control for **pan and tilt** — drag the cursor around
 the pad and the attached moving fixtures follow. It's the natural way to position
-moving heads and scanners by hand from the [Virtual Console](VirtualConsole.md).
+moving heads and scanners by hand from the [Virtual Console](/virtual-console).
 
 The pad's horizontal axis drives **pan** and the vertical axis drives **tilt**.
 The whole area represents the complete range of movement your fixtures can reach:

--- a/pages/08.virtual-console/08.cue-list/default.v5.md
+++ b/pages/08.virtual-console/08.cue-list/default.v5.md
@@ -3,10 +3,10 @@ title: 'Cue List'
 date: '03:34 22-08-2023'
 ---
 
-A **Cue List** plays a [Chaser](ChaserEditor.md) one cue (step) at a time, in
+A **Cue List** plays a [Chaser](/function-manager/chaser-editor) one cue (step) at a time, in
 order — exactly like a theatrical cue stack. It's the go-to widget for running a
 scripted show where you advance through looks with a **GO** button. The
-[Virtual Console](VirtualConsole.md).
+[Virtual Console](/virtual-console).
 
 Attach a chaser by dragging it onto the widget or from the settings; each chaser
 step becomes a cue in the list.

--- a/pages/08.virtual-console/10.frame/default.v5.md
+++ b/pages/08.virtual-console/10.frame/default.v5.md
@@ -3,12 +3,12 @@ title: Frame
 date: '03:39 22-08-2023'
 ---
 
-A **Frame** is a container in the [Virtual Console](VirtualConsole.md) that
+A **Frame** is a container in the [Virtual Console](/virtual-console) that
 groups other widgets together. Use it to organise the console into sections, to
 move and show/hide a whole group at once, and to add multi-page sub-areas.
 
 > For a frame in which only one function plays at a time, see
-> [Solo Frame](VCSoloFrame.md). A Solo Frame shares all the settings below and
+> [Solo Frame](../solo-frame). A Solo Frame shares all the settings below and
 > adds the solo rule.
 
 ## Settings
@@ -40,7 +40,7 @@ sub-console:
 
 * Drop widgets onto a frame to make them children of it; moving the frame moves
   them all.
-* Use a [Solo Frame](VCSoloFrame.md) for any group where two looks shouldn't run
+* Use a [Solo Frame](../solo-frame) for any group where two looks shouldn't run
   together.
 * Combine **Enable pages** with **Clone first page widgets** to build a paged
   section that keeps its master controls visible on every page.

--- a/pages/08.virtual-console/11.solo-frame/default.v5.md
+++ b/pages/08.virtual-console/11.solo-frame/default.v5.md
@@ -3,8 +3,8 @@ title: 'Solo Frame'
 date: '03:43 22-08-2023'
 ---
 
-A **Solo Frame** is a special [Frame](VCFrame.md) in the
-[Virtual Console](VirtualConsole.md) with one extra rule: only **one** of the
+A **Solo Frame** is a special [Frame](../frame) in the
+[Virtual Console](/virtual-console) with one extra rule: only **one** of the
 functions inside it can play at a time. Starting a function automatically stops
 any other function running from a widget in the same frame.
 
@@ -13,7 +13,7 @@ be mutually exclusive — a row of colour buttons, a bank of scene "states", or 
 palette where selecting a new look replaces the previous one. Without it you'd
 have to stop the old look manually before starting the new one.
 
-A Solo Frame is the same widget as a [Frame](VCFrame.md) and shares all of its
+A Solo Frame is the same widget as a [Frame](../frame) and shares all of its
 settings; it simply adds the solo behaviour and the **Solo Frame Options**
 section.
 
@@ -22,13 +22,13 @@ section.
 * When a widget inside the frame **starts a function**, every other function
   started by widgets in the same frame is **stopped**.
 * This applies to the widgets directly contained in the frame (for example its
-  [Buttons](VCButton.md)), giving you a clean one-at-a-time selector.
+  [Buttons](../button)), giving you a clean one-at-a-time selector.
 * It only affects functions started *from within this frame* — functions running
   elsewhere on the console are not touched.
 
 ## Settings
 
-A Solo Frame has all the [Frame settings](VCFrame.md#settings) — Header, Pages,
+A Solo Frame has all the [Frame settings](../frame#settings) — Header, Pages,
 Shortcuts — plus:
 
 ### Solo Frame Options
@@ -41,8 +41,8 @@ Shortcuts — plus:
 ## Creating one
 
 * Drag **Solo Frame** from the widget list onto the page, **or**
-* When creating a [Button Matrix](VCButtonMatrix.md) or
-  [Slider Matrix](VCSliderMatrix.md), choose **Solo** as the frame type to wrap
+* When creating a [Button Matrix](../button-matrix) or
+  [Slider Matrix](../slider-matrix), choose **Solo** as the frame type to wrap
   the whole grid in a Solo Frame.
 
 ## Tips

--- a/pages/08.virtual-console/12.label/default.v5.md
+++ b/pages/08.virtual-console/12.label/default.v5.md
@@ -3,7 +3,7 @@ title: Label
 date: '03:44 22-08-2023'
 ---
 
-A **Label** is a static piece of text on the [Virtual Console](VirtualConsole.md).
+A **Label** is a static piece of text on the [Virtual Console](/virtual-console).
 It does nothing when clicked — its job is to **title and organise** the console:
 section headings, page names, notes for the operator, and so on.
 
@@ -18,7 +18,7 @@ shared by every widget:
 * **Background image** — an optional image behind the text.
 * **Z-Index** — stacking order.
 
-See [Basic properties](VirtualConsole.md#basic-properties-all-widgets) for the
+See [Basic properties](/virtual-console#basic-properties-all-widgets) for the
 full list.
 
 ## Tips

--- a/pages/08.virtual-console/13.audio-triggers/default.v5.md
+++ b/pages/08.virtual-console/13.audio-triggers/default.v5.md
@@ -6,7 +6,7 @@ date: '03:46 22-08-2023'
 An **Audio Triggers** widget listens to live audio (from the computer's audio
 input) and uses its **frequency spectrum** to drive functions, DMX channels or
 other widgets. It's how you make lights react to music automatically in the
-[Virtual Console](VirtualConsole.md).
+[Virtual Console](/virtual-console).
 
 The incoming sound is split into a number of **frequency bars** (bass to treble),
 and each bar can be assigned a target that it controls as the music plays.

--- a/pages/08.virtual-console/14.clock/default.v5.md
+++ b/pages/08.virtual-console/14.clock/default.v5.md
@@ -6,7 +6,7 @@ taxonomy:
         - docs
 ---
 
-A **Clock** widget shows time on the [Virtual Console](VirtualConsole.md) — as a
+A **Clock** widget shows time on the [Virtual Console](/virtual-console) — as a
 running clock, a stopwatch or a countdown — and can **schedule functions** to
 start and stop at set times. It's used for timed and unattended shows (e.g. a
 museum or shop window that runs to a daily schedule).

--- a/pages/10.plugins/01.art-net/default.v4.md
+++ b/pages/10.plugins/01.art-net/default.v4.md
@@ -59,4 +59,4 @@ Here the links to download the tools:
 Compatibility
 -------------
 
-Compatible Art-Net devices are listed on the [compatibility](https://qlcplus.org/discover/compatibility) page of the QLC+ website.
+Compatible Art-Net devices are listed on the [compatibility](https://www.qlcplus.org/discover/compatibility) page of the QLC+ website.

--- a/pages/10.plugins/01.art-net/default.v4_ca.md
+++ b/pages/10.plugins/01.art-net/default.v4_ca.md
@@ -58,4 +58,4 @@ Aquí els enllaços per descarregar les eines:
 Compatibilitat
 -------------
 
-Els dispositius Art-Net compatibles estan enumerats a la pàgina de [compatibilitat](https://qlcplus.org/discover/compatibility) del lloc web de QLC+.
+Els dispositius Art-Net compatibles estan enumerats a la pàgina de [compatibilitat](https://www.qlcplus.org/discover/compatibility) del lloc web de QLC+.

--- a/pages/10.plugins/01.art-net/default.v4_de.md
+++ b/pages/10.plugins/01.art-net/default.v4_de.md
@@ -59,4 +59,4 @@ Hier die Links zum Herunterladen der Tools:
 Kompatibilität
 -------------
 
-Kompatible Art-Net-Geräte sind auf der [Kompatibilitätsseite](https://qlcplus.org/discover/compatibility) der QLC+-Website aufgeführt.
+Kompatible Art-Net-Geräte sind auf der [Kompatibilitätsseite](https://www.qlcplus.org/discover/compatibility) der QLC+-Website aufgeführt.

--- a/pages/10.plugins/01.art-net/default.v4_de.md
+++ b/pages/10.plugins/01.art-net/default.v4_de.md
@@ -59,4 +59,4 @@ Hier die Links zum Herunterladen der Tools:
 Kompatibilität
 -------------
 
-Kompatible Art-Net-Geräte sind auf der [Kompatibilitäts](https://qlcplus.org/discover/compatibility) Seite der QLC+ Website aufgeführt.
+Kompatible Art-Net-Geräte sind auf der [Kompatibilitätsseite](https://qlcplus.org/discover/compatibility) der QLC+-Website aufgeführt.

--- a/pages/12.advanced/01.web-interface/default.v5.md
+++ b/pages/12.advanced/01.web-interface/default.v5.md
@@ -30,7 +30,7 @@ From any modern browser (on any device on the same network) connect to:
 **http://\[IP address\]:9999**
 
 where *\[IP address\]* is the address of the machine running QLC+ — for example
-`http://192.168.0.100:9999`. The browser must support **WebSockets**, which QLC+
+`http://192.168.0.100:9999`. The browser must support [WebSockets](https://caniuse.com/mdn-api_websocket), which QLC+
 uses to talk to the page in real time.
 
 The web interface has three pages:


### PR DESCRIPTION
This PR fixes broken internal links in the new `v5` docs and adds some minor improvements to the `README` file (similar to [this](https://github.com/mcallegari/qlcplus/commit/1ee17b39b24c58e0bfbafa35e67978c4dbcaa065)).

I know the documentation for v5 is still a work in progress, but this will improve the already existing parts.