### PR TITLE
3D View: document the custom item Name and Color settings

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -300,6 +300,7 @@ Nodle
 capitalisation
 colour
 colours
+grey
 Automat
 stoponexit
 waitfunctionstop

--- a/pages/03.fixtures-and-functions/04.3d-view/docs.v5.md
+++ b/pages/03.fixtures-and-functions/04.3d-view/docs.v5.md
@@ -75,5 +75,13 @@ You can add your own 3D meshes to the scene (decor, set pieces, trusses, etc.):
   to place in the scene.
 * **Remove** (－) — delete the selected custom items.
 * **Normalize** (compress icon) — resets the selected items to a standard size.
+* **Name** — the name the item is listed under. It starts as the file name of
+  the mesh, so renaming is how you tell two copies of the same mesh apart.
+  Available when a single item is selected.
+* **Color** — click the colour swatch to choose a base colour for the selected
+  items. The colour tints the mesh rather than flooding it, so a mesh that
+  carries its own materials keeps its shading: the folds of a curtain stay
+  visible once it is turned red. Set it back to the default grey for the
+  mesh's own appearance.
 * The list below shows all custom items; click one to select it (and edit its
-  position, rotation and scale above).
+  name, colour, position, rotation and scale above).


### PR DESCRIPTION
Documents the **Name** field and the **Color** swatch added to the 3D View "Custom items" section by the corresponding qlcplus PR: https://github.com/mcallegari/qlcplus/pull/2128

Two bullets added to `pages/03.fixtures-and-functions/04.3d-view/docs.v5.md`, in the order the controls appear in the panel, and the list bullet below them updated to mention the two new fields. The wording follows the **Gel color** bullet in the 2D View page, which describes the analogous colour swatch there.

Both bullets cover a point that is not obvious from the controls themselves: a name is only editable when a single item is selected, since it identifies one item; and the colour tints the mesh rather than replacing its own colours, so a mesh with materials of its own keeps its shading and the default grey leaves it exactly as authored.

Also adds `grey` to `.wordlist.txt`, next to the `colour` and `colours` entries already there. The `.spellcheck.yml` pipeline asks for `en_GB` under a misspelled `apsell` key, so the check falls back to `en_US` and flags British spellings.