### PR TITLE
3D View: document the Rendering "Lumens" setting

### DIFF
--- a/pages/03.fixtures-and-functions/04.3d-view/docs.v5.md
+++ b/pages/03.fixtures-and-functions/04.3d-view/docs.v5.md
@@ -56,23 +56,23 @@ settings panel. Its sections can be expanded and collapsed.
   the beams in the air; use **Smoke amount** for those.
 * **Lumens (experimental)** — render your rig photometrically instead of giving
   every fixture the same output (off by default). Two things change when you
-  tick it. Each fixture is scaled by its real output: a 20000 lumen stage wash
-  and a small LED PAR light the stage very differently in reality, and now they
-  do so in the 3D view as well. The brightness comes from the **Lumens** value
-  in the fixture definition's physical properties, spread over the beam angle
-  so a narrow beam of the same output lands more intensely than a wide one, and
-  measured against the brightest fixture in your project, so that fixture keeps
-  the brightness it had and the rest fall in below it. Light also falls off with
-  distance, as it does in the room: a fixture hung high lays a wider, dimmer
-  pool than the same fixture hung low, and zooming a beam in concentrates it.
-  The distance light travels is measured against the scale of your own rig — the
-  average height your fixtures are placed at — so a small stage and an arena
-  each expose sensibly without a setting to tell them apart. A fixture whose
-  definition leaves Lumens unset is treated as being as bright as the reference,
-  so it never goes dark; if no fixture in the project has the value, nothing
-  changes. Use **Fixture light** alongside it to set the overall level.
-
-    This setting is marked experimental because the look it produces may still
+  tick it:
+  1. Each fixture is scaled by its real output: a 20000 lumen stage wash
+    and a small LED PAR light the stage very differently in reality, and now they
+    do so in the 3D view as well. The brightness comes from the **Lumens** value
+    in the fixture definition's physical properties, spread over the beam angle
+    so a narrow beam of the same output lands more intensely than a wide one, and
+    measured against the brightest fixture in your project, so that fixture keeps
+    the brightness it had and the rest fall in below it
+  2. Light falls off with distance, as it does in the room: a fixture hung high lays a wider, dimmer
+    pool than the same fixture hung low, and zooming a beam in concentrates it.
+    The distance light travels is measured against the scale of your own rig — the
+    average height your fixtures are placed at — so a small stage and an arena
+    each expose sensibly without a setting to tell them apart. A fixture whose
+    definition leaves Lumens unset is treated as being as bright as the reference,
+    so it never goes dark; if no fixture in the project has the value, nothing
+    changes. Use **Fixture light** alongside it to set the overall level.
+  * This setting is marked experimental because the look it produces may still
     change. It depends on your fixture definitions carrying sensible Lumens and
     beam angle figures, and many do not. It also does not yet handle floor standing
     fixtures well: uplighters are averaged in with the hung rig when the

--- a/pages/03.fixtures-and-functions/04.3d-view/docs.v5.md
+++ b/pages/03.fixtures-and-functions/04.3d-view/docs.v5.md
@@ -54,6 +54,32 @@ settings panel. Its sections can be expanded and collapsed.
   all detail. Turn this down to bring the surfaces back without dimming the
   environment, which **Ambient light** controls separately. It does not affect
   the beams in the air; use **Smoke amount** for those.
+* **Lumens (experimental)** — render your rig photometrically instead of giving
+  every fixture the same output (off by default). Two things change when you
+  tick it. Each fixture is scaled by its real output: a 20000 lumen stage wash
+  and a small LED PAR light the stage very differently in reality, and now they
+  do so in the 3D view as well. The brightness comes from the **Lumens** value
+  in the fixture definition's physical properties, spread over the beam angle
+  so a narrow beam of the same output lands more intensely than a wide one, and
+  measured against the brightest fixture in your project, so that fixture keeps
+  the brightness it had and the rest fall in below it. Light also falls off with
+  distance, as it does in the room: a fixture hung high lays a wider, dimmer
+  pool than the same fixture hung low, and zooming a beam in concentrates it.
+  The distance light travels is measured against the scale of your own rig — the
+  average height your fixtures are placed at — so a small stage and an arena
+  each expose sensibly without a setting to tell them apart. A fixture whose
+  definition leaves Lumens unset is treated as being as bright as the reference,
+  so it never goes dark; if no fixture in the project has the value, nothing
+  changes. Use **Fixture light** alongside it to set the overall level.
+
+    This setting is marked experimental because the look it produces may still
+    change. It depends on your fixture definitions carrying sensible Lumens and
+    beam angle figures, and many do not. It also does not yet handle floor standing
+    fixtures well: uplighters are averaged in with the hung rig when the
+    reference distance is worked out, so a rig that mixes the two can render its
+    uplighters very hot. Turning **Fixture light** down pulls the frame back if
+    that happens. The beams in the air are not affected by the distance falloff
+    yet, only the light landing on surfaces.
 * **Smoke amount** — how much atmospheric haze is in the air (0–100%), which
   makes beams more visible.
 * **Show FPS** — displays a frame-rate counter, useful for judging performance.

--- a/pages/03.fixtures-and-functions/04.3d-view/docs.v5.md
+++ b/pages/03.fixtures-and-functions/04.3d-view/docs.v5.md
@@ -47,6 +47,13 @@ settings panel. Its sections can be expanded and collapsed.
   Higher settings look better but demand more from your graphics hardware.
 * **Ambient light** — overall brightness of the scene when no fixtures are lit
   (0–100%).
+* **Fixture light** — a global multiplier on the light your fixtures cast onto
+  the stage and the set (0–200%, 100% by default). The 3D view adds the output
+  of every fixture together, so a rig with many fixtures pointed at the same
+  area can wash the stage out to flat white or full-intensity color and lose
+  all detail. Turn this down to bring the surfaces back without dimming the
+  environment, which **Ambient light** controls separately. It does not affect
+  the beams in the air; use **Smoke amount** for those.
 * **Smoke amount** — how much atmospheric haze is in the air (0–100%), which
   makes beams more visible.
 * **Show FPS** — displays a frame-rate counter, useful for judging performance.


### PR DESCRIPTION
Documents the new **Lumens** setting in the 3D View "Rendering" section, added by the corresponding qlcplus PR: https://github.com/mcallegari/qlcplus/pull/2129

Until now every fixture in the 3D view emitted the same amount of light regardless of what it is, and that light landed just as brightly however far it had travelled, so a large stage wash and a small LED PAR laid identical pools and a fixture hung high looked the same as one hung low. The setting renders the rig photometrically instead: each fixture scaled by the `Lumens` value in its definition, spread over its beam angle and measured against the brightest fixture in the project, with the light then falling off over the distance it travels, referenced to the average height the project's own fixtures are placed at.

The bullet covers what a user needs in order to decide whether to tick it: where the number comes from, that a narrow beam of the same output lands more intensely than a wide one, that a definition leaving Lumens unset is treated as being as bright as the reference so it never goes dark, that a project where no fixture carries the value renders unchanged, and that **Fixture light** is what sets the overall level.

The setting is labelled "Lumens (experimental)" in the UI, so the bullet carries a short indented paragraph saying why and recording what it does not yet handle: fixture definitions that carry no sensible Lumens or beam angle figures, floor standing fixtures being averaged in with the hung rig when the reference distance is derived, and the volumetric beams in the air, which the falloff does not yet reach.

Single bullet added to `pages/03.fixtures-and-functions/04.3d-view/docs.v5.md`, in the order the settings appear in the panel.

Based on the branch of #133, because it edits the same list immediately after that branch's bullet, so that PR's commit is also in this diff. Reviewing or merging #133 first will reduce this one to the single Lumens commit.
